### PR TITLE
Fix README programmatic example import

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,7 @@ In interactive mode, type `/fund 200` at the prompt to deposit $200 into the liv
 
 ```python
 from solvent.agent import Solvent
+from solvent.jobs import SAMPLE_JOBS
 
 agent = Solvent(seed_cents=10_000)          # reset treasury, seed $100
 agent.handle_job(SAMPLE_JOBS[0])            # process one job


### PR DESCRIPTION
### Motivation
- The Programmatic usage snippet in `README.md` referenced `SAMPLE_JOBS` but no longer imported it, causing a `NameError` for users who copy the example.

### Description
- Add `from solvent.jobs import SAMPLE_JOBS` to the Programmatic code example in `README.md` so the documented snippet runs as written.

### Testing
- Ran the updated snippet (importing `Solvent` and `SAMPLE_JOBS`, calling `agent.handle_job(...)` and `agent.run(...)`) and it executed and printed snapshot values without error.
- Ran `pytest -q` and the test suite completed successfully (`96 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a33622e96c883248f039cf621cb9635)