### PR TITLE
Production upgrade: webhook Stripe, async worker, tool agent, auto-improve

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,10 @@ treasury_dashboard.html
 data/reports/*.md
 data/reports/*.pdf
 
+# Runtime logs and email outbox (delivery + observability)
+data/solvent.log
+data/outbox/
+
 # Keep the data/reports directory structures but ignore content
 !data/
 !data/reports/

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -28,11 +28,15 @@ between a demo bot and a business.
  └─────┬───────┘ accept
        ▼
  ┌─────────────┐   EARN
- │   STRIPE    │ ── Payment Link → poll/webhook until paid ──▶ + revenue
- └─────┬───────┘    (records cs_... + pi_... on ledger)
+ │   STRIPE    │ ── Checkout Session → webhook (primary) ──▶ + revenue
+ └─────┬───────┘    idempotent stages in SQLite
        ▼
  ┌─────────────┐   FULFIL
- │  NEMOTRON   │ ── produces the research brief ──▶ itemized resource usage
+ │  NEMOTRON   │ ── bounded tool-calling research loop ──▶ actual COGS
+ └─────┬───────┘
+       ▼
+ ┌─────────────┐   DELIVER
+ │  HOSTED+SMTP│ ── signed brief URL + optional email
  └─────┬───────┘
        ▼
  ┌─────────────┐   SPEND (each payment screened first)
@@ -52,8 +56,12 @@ can violate policy — the business is safe by construction and profitable by ru
 |---|---|---|
 | **Reasoning / the analyst** | **NVIDIA Nemotron** (Llama-3.1-Nemotron-Ultra) via the OpenAI-compatible endpoint | `solvent/nemotron.py` |
 | **Spend safety** | **NVIDIA NemoClaw**-style policy sandbox — every payment screened before it executes | `solvent/guardrails.py` |
-| **Earn + Spend** | **Stripe Skills** — Payment Links with checkout polling/webhook verification; PaymentIntent audit trail; Issuing virtual cards for outbound spend (test mode) | `solvent/stripe_client.py` |
-| **Agent orchestration** | **Hermes / Nous** tool-calling agent loop | `solvent/agent.py` |
+| **Earn + Spend** | **Stripe** — Checkout Sessions, webhooks, idempotency keys; Issuing for outbound spend (test mode) | `solvent/stripe_client.py` |
+| **Agent orchestration** | Idempotent **stage machine** + bounded Nemotron tool loop | `solvent/stages.py`, `solvent/tools.py`, `solvent/agent.py` |
+| **Async processing** | SQLite queue + worker resume | `solvent/worker.py`, `solvent/queue.py` |
+| **Delivery** | Hosted briefs + SMTP/outbox | `solvent/delivery.py`, `solvent/server.py` |
+| **Auto-improvement** | Metrics-driven tuning | `solvent/improver.py` |
+| **Observability** | JSON logs + Stripe reconciliation | `solvent/observability.py`, `solvent/reconcile.py` |
 | **Economic memory** | the treasury / ledger that makes it a business | `solvent/treasury.py`, `solvent/pricing.py` |
 
 ## Key design choices
@@ -75,15 +83,23 @@ can violate policy — the business is safe by construction and profitable by ru
 ## Files
 ```
 solvent/
-  agent.py         the orchestrator (earn → fulfil → spend → book)
-  treasury.py      the ledger / balance sheet
-  pricing.py       the margin gate
+  agent.py         thin orchestrator delegating to stages
+  stages.py        idempotent stage machine (quote→paid→fulfill→deliver→spend)
+  worker.py        async job processor + resume incomplete jobs
+  server.py        FastAPI: webhooks, /jobs, /briefs (optional deps)
+  tools.py         allowlisted research tools
+  delivery.py      hosted briefs + SMTP/outbox email
+  observability.py structured JSON logging
+  improver.py      auto-tune pricing from job metrics
+  reconcile.py     Stripe ↔ ledger reconciliation
+  treasury.py      ledger, jobs, stages, metrics (SQLite)
+  pricing.py       margin gate + COGS overrides
   guardrails.py    NemoClaw-style spend policy
-  stripe_client.py two-sided Stripe layer (earn + spend)
-  nemotron.py      NVIDIA Nemotron client (+ offline stub)
-  service.py       the product: an on-demand research brief
+  stripe_client.py Checkout Sessions + webhooks
+  nemotron.py      Nemotron client + bounded tool loop
+  service.py       research brief fulfillment
   jobs.py          sample inbound work
-  dashboard.py     renders the treasury to HTML
-run_demo.py        the full business loop
-demo_guardrails.py the safety story
+  dashboard.py     treasury HTML dashboard
+run_demo.py        CLI demo (--async, --serve)
+docs/PRODUCTION.md production deployment guide
 ```

--- a/README.md
+++ b/README.md
@@ -168,6 +168,28 @@ python3 demo_guardrails.py
 
 Shows five spend attempts and which ones the NemoClaw-style policy blocks — without starting the agent or touching Stripe.
 
+### Production mode (webhooks + async worker)
+
+```bash
+pip install -r requirements.txt -r requirements-serve.txt
+
+python3 -m solvent serve --port 8787   # webhooks + job API + hosted briefs
+python3 -m solvent worker              # resume incomplete jobs, process queue
+
+# Or dev convenience:
+python3 run_demo.py --serve --no-onboard
+```
+
+See [docs/PRODUCTION.md](docs/PRODUCTION.md) for Stripe webhook setup, SMTP delivery, reconciliation, and auto-tuning.
+
+### Operations
+
+```bash
+python3 -m solvent reconcile --since 7d   # Stripe ↔ ledger drift check
+python3 -m solvent tune                   # propose pricing improvements (dry-run)
+python3 -m solvent tune --apply             # apply after 5+ completed jobs
+```
+
 ---
 
 ## 🔑 Make It Real

--- a/docs/PRODUCTION.md
+++ b/docs/PRODUCTION.md
@@ -1,0 +1,100 @@
+# SOLVENT Production Guide
+
+Run SOLVENT as a webhook-first, async agent with hosted delivery.
+
+## Quick start (offline demo)
+
+```bash
+python3 run_demo.py --no-onboard
+```
+
+## HTTP server + worker (production shape)
+
+```bash
+pip install -r requirements.txt
+pip install -r requirements-serve.txt
+
+export SOLVENT_BASE_URL=http://127.0.0.1:8787
+export SOLVENT_DELIVERY_SECRET=change-me-in-production
+
+# Terminal 1 — API + webhooks + hosted briefs
+python3 -m solvent serve --port 8787
+
+# Terminal 2 — async job processor
+python3 -m solvent worker
+
+# Or combined dev mode:
+python3 run_demo.py --serve --no-onboard
+```
+
+## Stripe setup (test mode)
+
+1. Set `STRIPE_API_KEY=sk_test_...` or restricted `rk_test_...`
+2. Create webhook endpoint: `POST {SOLVENT_BASE_URL}/webhooks/stripe`
+3. Subscribe to `checkout.session.completed`
+4. Set `STRIPE_WEBHOOK_SECRET=whsec_...`
+5. Submit jobs via `POST /jobs` — response includes `checkout_url`
+
+Polling is disabled by default. For CLI-only test flows:
+
+```bash
+export SOLVENT_ALLOW_POLL=1
+```
+
+## Submit a job
+
+```bash
+curl -X POST http://127.0.0.1:8787/jobs \
+  -H 'Content-Type: application/json' \
+  -d '{"id":"J99","topic":"EV battery supply chain","budget_cents":7500,"customer_email":"you@example.com"}'
+```
+
+## Email delivery (optional)
+
+Without SMTP, briefs are written to `data/outbox/{job_id}.eml`.
+
+```bash
+export SMTP_HOST=smtp.example.com
+export SMTP_PORT=587
+export SMTP_USER=...
+export SMTP_PASS=...
+export SMTP_FROM=agent@yourdomain.com
+```
+
+## Operations
+
+```bash
+# Structured JSON logs
+export SOLVENT_LOG_JSON=1
+
+# Reconcile Stripe vs ledger
+python3 -m solvent reconcile --since 7d
+
+# Auto-improvement (dry-run by default)
+python3 -m solvent tune
+python3 -m solvent tune --apply
+```
+
+## Environment variables
+
+| Variable | Purpose |
+|----------|---------|
+| `STRIPE_API_KEY` | Test/restricted Stripe key |
+| `STRIPE_WEBHOOK_SECRET` | Webhook signature verification |
+| `SOLVENT_BASE_URL` | Checkout success URLs + hosted briefs |
+| `SOLVENT_DELIVERY_SECRET` | HMAC token for `/briefs/{id}` |
+| `SOLVENT_ASYNC` | Non-blocking payment (worker resumes jobs) |
+| `SOLVENT_ALLOW_POLL` | Legacy payment polling |
+| `SOLVENT_LOG_JSON` | JSON lines to stderr + `data/solvent.log` |
+| `NVIDIA_API_KEY` | Live Nemotron (optional) |
+| `SMTP_*` | Email delivery |
+
+## Architecture
+
+```
+POST /jobs → quote → Checkout Session → awaiting_payment
+     ↓ webhook checkout.session.completed
+worker → paid → fulfill (tool agent) → deliver → spend → book
+```
+
+Idempotent stages are recorded in SQLite (`job_stages`). Metrics in `job_metrics` feed `solvent tune`.

--- a/requirements-serve.txt
+++ b/requirements-serve.txt
@@ -1,0 +1,2 @@
+fastapi>=0.110.0
+uvicorn[standard]>=0.27.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,6 @@
 # SOLVENT runs with the Python standard library alone (offline stubs).
 # Install this ONLY if you want real Stripe test-mode payment links:
 stripe>=9.0.0
+
+# Tests
+pytest>=7.0.0

--- a/run_demo.py
+++ b/run_demo.py
@@ -15,6 +15,7 @@ Reconfigure: --onboard
 import sys
 import time
 import argparse
+import os
 from pathlib import Path
 from solvent.agent import Solvent
 from solvent.jobs import SAMPLE_JOBS
@@ -285,6 +286,17 @@ def main():
         action="store_true",
         help="keep existing database balance (do not reset treasury)",
     )
+    parser.add_argument(
+        "--async",
+        action="store_true",
+        dest="async_mode",
+        help="enqueue jobs and run background worker (non-blocking payment)",
+    )
+    parser.add_argument(
+        "--serve",
+        action="store_true",
+        help="start HTTP server + worker (requires requirements-serve.txt)",
+    )
     args = parser.parse_args()
 
     cfg = resolve_config(args)
@@ -292,6 +304,22 @@ def main():
 
     seed_cents = int(args.seed * 100)
     fresh = not args.keep_balance
+
+    if args.serve:
+        import threading
+        from solvent.worker import run_worker
+        from solvent.server import main as serve_main
+        t = threading.Thread(
+            target=run_worker,
+            kwargs={"poll_interval": 2.0, "seed_cents": seed_cents, "fresh": fresh},
+            daemon=True,
+        )
+        t.start()
+        serve_main()
+        return
+
+    if args.async_mode:
+        os.environ["SOLVENT_ASYNC"] = "1"
 
     if args.interactive:
         run_interactive_mode(seed_cents=seed_cents, fresh=fresh)

--- a/solvent/__main__.py
+++ b/solvent/__main__.py
@@ -1,6 +1,29 @@
-"""SOLVENT CLI entry point: python3 -m solvent"""
+"""SOLVENT CLI entry point: python3 -m solvent [serve|worker|tune|reconcile|demo]"""
 
-from run_demo import main
+import sys
+
+
+def main():
+    if len(sys.argv) > 1 and sys.argv[1] == "serve":
+        sys.argv.pop(1)
+        from .server import main as serve_main
+        serve_main()
+    elif len(sys.argv) > 1 and sys.argv[1] == "worker":
+        sys.argv.pop(1)
+        from .worker import main as worker_main
+        worker_main()
+    elif len(sys.argv) > 1 and sys.argv[1] == "tune":
+        sys.argv.pop(1)
+        from .improver import main as tune_main
+        tune_main()
+    elif len(sys.argv) > 1 and sys.argv[1] == "reconcile":
+        sys.argv.pop(1)
+        from .reconcile import main as reconcile_main
+        reconcile_main()
+    else:
+        from run_demo import main as demo_main
+        demo_main()
+
 
 if __name__ == "__main__":
     main()

--- a/solvent/agent.py
+++ b/solvent/agent.py
@@ -1,31 +1,36 @@
 """
-agent.py — the SOLVENT orchestrator (the Hermes/Nous agent loop).
+agent.py — the SOLVENT orchestrator.
 
-For each inbound job the agent:
-  1. QUOTES it through the margin gate (refuses unprofitable work).
-  2. EARNS — issues a Stripe payment link and collects payment up front.
-  3. FULFILS — runs the analyst (Nemotron) to produce the deliverable.
-  4. SPENDS — pays each vendor it consumed, every payment screened by guardrails.
-  5. BOOKS the job's P&L into the treasury.
-
-The whole thing is designed so that revenue is collected before cost is incurred
-and no individual payment can violate policy — an autonomous business that is
-safe by construction and profitable by rule.
+For each inbound job the agent runs an idempotent stage machine:
+  1. QUOTES through the margin gate
+  2. EARNS via Stripe Checkout (webhook-first; sync confirm in demo mode)
+  3. FULFILS via bounded Nemotron tool-calling
+  4. DELIVERS hosted brief + optional email
+  5. SPENDS on vendors (guardrail-screened)
+  6. BOOKS P&L into the treasury
 """
 
 from __future__ import annotations
 
+import os
 import time
-from .treasury import Treasury, fmt
-from .guardrails import Guardrails, GuardrailError
-from .pricing import quote, PricingPolicy
+
+from .treasury import Treasury
+from .guardrails import Guardrails
+from .pricing import PricingPolicy
 from .stripe_client import StripeClient
-from .security import sanitise_job, SOLVENTSecurityError
-from . import service
+from .stages import StageRunner, validate_and_coerce_job
 
 
 class Solvent:
-    def __init__(self, seed_cents: int = 10_000, fresh: bool = True, on_event: callable | None = None):
+    def __init__(
+        self,
+        seed_cents: int = 10_000,
+        fresh: bool = True,
+        on_event: callable | None = None,
+        *,
+        sync_payment: bool | None = None,
+    ):
         self.t = Treasury()
         if fresh:
             self.t.reset()
@@ -35,6 +40,21 @@ class Solvent:
         self.pricing = PricingPolicy()
         self.log: list[dict] = []
         self.on_event = on_event
+        if sync_payment is None:
+            sync_payment = os.environ.get("SOLVENT_ASYNC", "").strip() not in ("1", "true", "yes")
+        self._runner = StageRunner(
+            self.t,
+            self.guard,
+            self.stripe,
+            self.pricing,
+            on_event=self._capture_event,
+            sync_payment=sync_payment,
+        )
+
+    def _capture_event(self, event: dict):
+        self.log.append(event)
+        if self.on_event:
+            self.on_event(event)
 
     def _emit(self, **event):
         if "ts" not in event:
@@ -42,227 +62,24 @@ class Solvent:
         self.log.append(event)
         if self.on_event:
             self.on_event(event)
-        
-        # Real-time dashboard rendering
-        try:
-            from . import dashboard
-            dashboard.render(self.t.snapshot(), self.log)
-        except Exception:
-            pass
-            
         return event
 
     def handle_job(self, job: dict) -> dict:
-        # 0. INPUT VALIDATION & COERCION -------------------------------
-        if not isinstance(job, dict):
-            return self._emit(stage="declined", job_id="unknown", reason="job must be a dictionary")
+        return self._runner.run_job(job)
 
-        job_id = job.get("id")
-        if not job_id or not isinstance(job_id, str):
-            return self._emit(stage="declined", job_id="unknown", reason="missing or invalid job ID")
+    def advance_job(self, job_id: str) -> dict:
+        return self._runner.advance_job(job_id)
 
-        # SECURITY — sanitise all LLM-facing and external fields before
-        # any downstream system sees them (prompt injection, email injection,
-        # path traversal via job ID handled inside sanitise_job / service.fulfill)
-        try:
-            job = dict(job)  # work on a shallow copy; never mutate caller's dict
-            sanitise_job(job)
-        except SOLVENTSecurityError as exc:
-            reason = f"security violation: {exc}"
-            self.t.upsert_job(job_id, "failed", error_reason=reason)
-            return self._emit(stage="declined", job_id=job_id, reason=reason)
-
-        # Initial insert in jobs queue
-        topic = job.get("topic")
-        budget_cents = job.get("budget_cents")
-        customer_email = job.get("customer_email")
-        est_tokens = job.get("est_tokens")
-        market_data_calls = job.get("market_data_calls")
-        web_search_calls = job.get("web_search_calls")
-
-        self.t.upsert_job(
-            job_id,
-            "pending_quote",
-            topic=topic,
-            budget_cents=budget_cents,
-            customer_email=customer_email,
-            est_tokens=est_tokens,
-            market_data_calls=market_data_calls,
-            web_search_calls=web_search_calls
-        )
-
-        if not topic or not isinstance(topic, str) or not topic.strip():
-            reason = "missing or blank topic"
-            self.t.upsert_job(job_id, "failed", error_reason=reason)
-            return self._emit(stage="declined", job_id=job_id, reason=reason)
-
-        # Coerce and validate budget
-        if budget_cents is None:
-            reason = "missing budget_cents"
-            self.t.upsert_job(job_id, "failed", error_reason=reason)
-            return self._emit(stage="declined", job_id=job_id, reason=reason)
-        try:
-            budget_cents = int(float(budget_cents))
-            if budget_cents < 0:
-                reason = "budget cannot be negative"
-                self.t.upsert_job(job_id, "failed", error_reason=reason)
-                return self._emit(stage="declined", job_id=job_id, reason=reason)
-            # Cap maximum budget at $10,000 to prevent overflow/abuse
-            if budget_cents > 1_000_000:
-                reason = "budget exceeds maximum limit"
-                self.t.upsert_job(job_id, "failed", error_reason=reason)
-                return self._emit(stage="declined", job_id=job_id, reason=reason)
-            job["budget_cents"] = budget_cents
-        except (ValueError, TypeError):
-            reason = "budget_cents must be a valid numeric value"
-            self.t.upsert_job(job_id, "failed", error_reason=reason)
-            return self._emit(stage="declined", job_id=job_id, reason=reason)
-
-        # Coerce and validate parameters
-        for param, default_val in [("est_tokens", 8_000), ("market_data_calls", 2), ("web_search_calls", 6)]:
-            val = job.get(param)
-            if val is None:
-                val = default_val
-            try:
-                val = int(float(val))
-                if val < 0:
-                    reason = f"{param} cannot be negative"
-                    self.t.upsert_job(job_id, "failed", error_reason=reason)
-                    return self._emit(stage="declined", job_id=job_id, reason=reason)
-                # Cap inputs to avoid resource exhaustion/unbounded loops
-                if param == "est_tokens" and val > 100_000:
-                    reason = "est_tokens exceeds maximum limit"
-                    self.t.upsert_job(job_id, "failed", error_reason=reason)
-                    return self._emit(stage="declined", job_id=job_id, reason=reason)
-                if param in ("market_data_calls", "web_search_calls") and val > 50:
-                    reason = f"{param} exceeds maximum limit"
-                    self.t.upsert_job(job_id, "failed", error_reason=reason)
-                    return self._emit(stage="declined", job_id=job_id, reason=reason)
-                job[param] = val
-            except (ValueError, TypeError):
-                reason = f"{param} must be a valid numeric value"
-                self.t.upsert_job(job_id, "failed", error_reason=reason)
-                return self._emit(stage="declined", job_id=job_id, reason=reason)
-
-        # Update job queue entry with fully coerced and validated values
-        self.t.upsert_job(
-            job_id,
-            "pending_quote",
-            topic=job["topic"],
-            budget_cents=job["budget_cents"],
-            customer_email=job.get("customer_email", "client@example.com"),
-            est_tokens=job["est_tokens"],
-            market_data_calls=job["market_data_calls"],
-            web_search_calls=job["web_search_calls"]
-        )
-
-        # 1. QUOTE -----------------------------------------------------
-        q = quote(job, self.pricing)
-        self._emit(stage="quote", job_id=job["id"], title=job["topic"],
-                   price=q.price_cents, est_cost=q.est_cost_cents,
-                   margin_pct=q.margin_pct, accept=q.accept, reason=q.reason)
-        if not q.accept:
-            self.t.upsert_job(job_id, "failed", error_reason=q.reason)
-            return self._emit(stage="declined", job_id=job["id"], reason=q.reason)
-
-        # 1.5. PRE-SCREEN RESOURCE EXHAUSTION --------------------------
-        with self.t.lock():
-            # Check if estimated job fulfillment cost would exceed remaining daily budget
-            if self.guard._spent_last_24h() + q.est_cost_cents > self.guard.policy.daily_budget_cents:
-                reason = "fulfilment cost would exceed 24h spend budget limit"
-                self.t.upsert_job(job_id, "failed", error_reason=reason)
-                return self._emit(stage="declined", job_id=job["id"], reason=reason)
-
-            # Check if expected balance after fulfillment would drop below the cash reserve
-            projected_balance = self.t.balance_cents() + q.price_cents - q.est_cost_cents
-            if projected_balance < self.guard.policy.min_reserve_cents:
-                reason = "fulfilment would breach minimum cash reserve limit"
-                self.t.upsert_job(job_id, "failed", error_reason=reason)
-                return self._emit(stage="declined", job_id=job["id"], reason=reason)
-
-        # 2. EARN ------------------------------------------------------
-        self.t.upsert_job(job_id, "awaiting_payment")
-        link = self.stripe.create_payment_link(
-            name=f"Research brief: {job['topic'][:60]}",
-            amount_cents=q.price_cents,
-            customer_email=job.get("customer_email", "client@example.com"),
-        )
-        self._emit(stage="invoice", job_id=job["id"], url=link["url"],
-                   amount=q.price_cents, simulated=link["simulated"])
-        payment = self.stripe.confirm_payment(link)
-        if not payment.get("paid"):
-            reason = payment.get("reason", "payment not received")
-            self.t.upsert_job(job_id, "awaiting_payment", error_reason=reason)
-            return self._emit(
-                stage="payment_pending",
-                job_id=job["id"],
-                reason=reason,
-                url=link["url"],
-                payment_link_id=link["id"],
-            )
-        self.t.earn(
-            payment["amount_cents"],
-            f"Payment for {job['id']}",
-            job_id=job["id"],
-            stripe_ref=payment["stripe_ref"],
-            stripe_session_id=payment.get("checkout_session_id"),
-            stripe_link_id=payment.get("payment_link_id"),
-        )
-        self._emit(
-            stage="paid",
-            job_id=job["id"],
-            amount=payment["amount_cents"],
-            payment_intent=payment["stripe_ref"],
-            checkout_session=payment.get("checkout_session_id"),
-            payment_link=payment.get("payment_link_id"),
-        )
-
-        # 3. FULFIL & 4. SPEND (inside try-except to trigger refund if blocked/failed)
-        self.t.upsert_job(job_id, "in_progress")
-        payment_intent_id = payment["stripe_ref"]
-        paid_amount = payment["amount_cents"]
-        
-        try:
-            # 3. FULFIL ------------------------------------------------
-            result = service.fulfill(job)
-            self._emit(stage="fulfilled", job_id=job["id"],
-                       deliverable=result["deliverable_path"], tokens=result["tokens"])
-
-            # 4. SPEND (each payment screened by guardrails under lock) ----
-            job_margin = q.margin_cents
-            for vendor, amount, memo in result["resources_used"]:
-                if amount <= 0:
-                    continue
-                with self.t.lock():
-                    if not self.guard.approve(amount, vendor, projected_job_margin_cents=job_margin):
-                        self._emit(stage="spend_blocked", job_id=job["id"], vendor=vendor,
-                                   amount=amount, memo=memo)
-                        raise GuardrailError(f"spend to {vendor} of {amount}c rejected by guardrails")
-                    pay = self.stripe.pay_vendor(vendor, amount, memo)
-                    self.t.spend(amount, memo, job_id=job["id"], vendor=vendor, stripe_ref=pay["id"])
-                    self._emit(stage="spend", job_id=job["id"], vendor=vendor, amount=amount, memo=memo)
-
-            # 5. BOOK P&L ----------------------------------------------
-            self.t.upsert_job(job_id, "completed")
-            pnl = self.t.job_pnl_cents(job["id"])
-            return self._emit(stage="booked", job_id=job["id"], job_pnl=pnl,
-                              balance=self.t.balance_cents(), status="completed")
-
-        except Exception as e:
-            reason = str(e)
-            refund = self.stripe.refund_payment(payment_intent_id, paid_amount)
-            self.t.spend(
-                amount_cents=paid_amount,
-                memo=f"Refund for job {job_id} due to block/failure: {reason}",
-                job_id=job_id,
-                stripe_ref=refund["id"]
-            )
-            self._emit(stage="refunded", job_id=job_id, amount=paid_amount, reason=reason)
-            self.t.upsert_job(job_id, "failed", error_reason=reason)
-            
-            pnl = self.t.job_pnl_cents(job_id)
-            return self._emit(stage="booked", job_id=job_id, job_pnl=pnl,
-                              balance=self.t.balance_cents(), status="failed")
+    def enqueue_job(self, job: dict) -> dict:
+        """Validate and persist a job for async worker processing."""
+        job, err = validate_and_coerce_job(job, self.t)
+        if err:
+            return self._emit(stage="declined", job_id=job.get("id", "unknown") if job else "unknown", reason=err)
+        q = self._runner._stage_quote(job)
+        if q.get("stage") == "declined" or not q.get("accept"):
+            return q
+        checkout = self._runner._stage_checkout(job, q)
+        return checkout
 
     def run(self, jobs: list[dict]) -> dict:
         for job in jobs:

--- a/solvent/config.py
+++ b/solvent/config.py
@@ -26,6 +26,9 @@ class SolventConfig:
     nemotron_model: str = "nvidia/llama-3.1-nemotron-ultra-253b-v1"
     interaction_mode: str = "batch"
     stripe_test_mode: bool = False
+    base_url: str = "http://127.0.0.1:8787"
+    worker_enabled: bool = False
+    async_mode: bool = False
 
     def validate(self) -> None:
         if self.model not in VALID_MODELS:
@@ -86,3 +89,10 @@ def apply_config(config: SolventConfig) -> None:
         os.environ.pop("SOLVENT_FORCE_STRIPE_SIMULATE", None)
     else:
         os.environ["SOLVENT_FORCE_STRIPE_SIMULATE"] = "1"
+
+    if config.base_url:
+        os.environ["SOLVENT_BASE_URL"] = config.base_url
+    if config.async_mode:
+        os.environ["SOLVENT_ASYNC"] = "1"
+    else:
+        os.environ.pop("SOLVENT_ASYNC", None)

--- a/solvent/dashboard.py
+++ b/solvent/dashboard.py
@@ -130,6 +130,35 @@ def render(snapshot: dict, log: list[dict]) -> Path:
     if not expense_breakdown_html:
         expense_breakdown_html = "<p class='no-data-msg'>No vendor expenses logged yet.</p>"
 
+    # 3b. Ops: stuck jobs and margin drift from treasury metrics
+    ops_html = ""
+    try:
+        from .treasury import Treasury
+        t = Treasury()
+        stuck = [j for j in t.list_jobs() if j.get("status") in ("awaiting_payment", "in_progress", "paid_pending_fulfill")]
+        metrics = t.list_metrics()
+        drift_rows = [
+            m for m in metrics
+            if m.get("margin_drift_cents") is not None and abs(m.get("margin_drift_cents", 0)) > 0
+        ]
+        if stuck:
+            ops_html += "<h3>Stuck jobs</h3><ul>"
+            for j in stuck[:10]:
+                ops_html += f"<li>{j['id']}: {j.get('status')} — {j.get('topic', '')[:40]}</li>"
+            ops_html += "</ul>"
+        if drift_rows:
+            ops_html += "<h3>Margin drift</h3><ul>"
+            for m in drift_rows[-10:]:
+                ops_html += (
+                    f"<li>{m['job_id']}: est {m.get('est_margin_pct')}% → "
+                    f"actual {m.get('actual_margin_pct')}% (drift {m.get('margin_drift_cents')}c)</li>"
+                )
+            ops_html += "</ul>"
+        if not ops_html:
+            ops_html = "<p class='no-data-msg'>No stuck jobs or margin drift.</p>"
+    except Exception:
+        ops_html = ""
+
     # 4. Group details by job for card listing
     from collections import defaultdict
     jobs_data = defaultdict(lambda: {
@@ -948,6 +977,10 @@ def render(snapshot: dict, log: list[dict]) -> Path:
       <div class="vendor-breakdown-list" id="expense-breakdown">
         {expense_breakdown_html}
       </div>
+      <h2 style="margin-top:24px;border-top:1px solid var(--color-border);padding-top:16px">Operations</h2>
+      <div class="vendor-breakdown-list" id="ops-panel">
+        {ops_html}
+      </div>
     </div>
 
     <div class="panel">
@@ -1179,6 +1212,7 @@ def render(snapshot: dict, log: list[dict]) -> Path:
         "margin_pct": s["margin_pct"],
         "chart_svg": chart_svg,
         "expense_breakdown_html": expense_breakdown_html,
+        "ops_html": ops_html,
         "job_cards_html": job_cards_html,
         "console_log_html": console_log_html,
         "jobs_data": dict(jobs_data),

--- a/solvent/delivery.py
+++ b/solvent/delivery.py
@@ -1,0 +1,122 @@
+"""Hosted brief delivery and optional SMTP email."""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import os
+import smtplib
+import time
+from email.mime.multipart import MIMEMultipart
+from email.mime.text import MIMEText
+from pathlib import Path
+
+OUTBOX_DIR = Path(__file__).resolve().parent.parent / "data" / "outbox"
+
+
+def _delivery_secret() -> str:
+    return os.environ.get("SOLVENT_DELIVERY_SECRET", "solvent-dev-secret-change-me")
+
+
+def make_delivery_token(job_id: str, ts: float | None = None) -> str:
+    ts = ts or time.time()
+    payload = f"{job_id}:{int(ts)}"
+    sig = hmac.new(_delivery_secret().encode(), payload.encode(), hashlib.sha256).hexdigest()
+    return f"{int(ts)}.{sig}"
+
+
+def verify_delivery_token(job_id: str, token: str, max_age_seconds: int = 7 * 86400) -> bool:
+    if not token or "." not in token:
+        return False
+    ts_str, sig = token.split(".", 1)
+    try:
+        ts = int(ts_str)
+    except ValueError:
+        return False
+    if abs(time.time() - ts) > max_age_seconds:
+        return False
+    payload = f"{job_id}:{ts}"
+    expected = hmac.new(_delivery_secret().encode(), payload.encode(), hashlib.sha256).hexdigest()
+    return hmac.compare_digest(expected, sig)
+
+
+def hosted_brief_url(base_url: str, job_id: str) -> str:
+    base = base_url.rstrip("/")
+    token = make_delivery_token(job_id)
+    return f"{base}/briefs/{job_id}?token={token}"
+
+
+def markdown_to_html(md: str) -> str:
+    """Minimal markdown → HTML without external deps."""
+    lines = md.splitlines()
+    html_lines: list[str] = []
+    for line in lines:
+        if line.startswith("# "):
+            html_lines.append(f"<h1>{_esc(line[2:])}</h1>")
+        elif line.startswith("## "):
+            html_lines.append(f"<h2>{_esc(line[3:])}</h2>")
+        elif line.startswith("### "):
+            html_lines.append(f"<h3>{_esc(line[4:])}</h3>")
+        elif line.startswith("- "):
+            html_lines.append(f"<li>{_esc(line[2:])}</li>")
+        elif line.strip() == "":
+            html_lines.append("<br/>")
+        else:
+            html_lines.append(f"<p>{_esc(line)}</p>")
+    body = "\n".join(html_lines)
+    return (
+        "<!DOCTYPE html><html><head><meta charset='utf-8'>"
+        "<title>SOLVENT Research Brief</title>"
+        "<style>body{font-family:system-ui,sans-serif;max-width:720px;margin:2rem auto;"
+        "line-height:1.6;color:#1a1a2e}h1{color:#0f3460}h2{color:#16213e}</style>"
+        "</head><body>" + body + "</body></html>"
+    )
+
+
+def _esc(text: str) -> str:
+    return (
+        text.replace("&", "&amp;")
+        .replace("<", "&lt;")
+        .replace(">", "&gt;")
+        .replace('"', "&quot;")
+    )
+
+
+def send_brief_email(
+    to_email: str,
+    job_id: str,
+    brief_path: Path,
+    hosted_url: str,
+) -> dict:
+    """Send brief via SMTP or write to outbox in simulate mode."""
+    text = brief_path.read_text(encoding="utf-8") if brief_path.is_file() else ""
+    subject = f"Your SOLVENT research brief ({job_id})"
+    body = (
+        f"Your research brief is ready.\n\n"
+        f"View online: {hosted_url}\n\n"
+        f"---\n{text[:8000]}"
+    )
+    host = os.environ.get("SMTP_HOST", "").strip()
+    if not host:
+        OUTBOX_DIR.mkdir(parents=True, exist_ok=True)
+        eml_path = OUTBOX_DIR / f"{job_id}.eml"
+        eml_path.write_text(
+            f"To: {to_email}\nSubject: {subject}\n\n{body}",
+            encoding="utf-8",
+        )
+        return {"simulated": True, "path": str(eml_path), "to": to_email}
+    port = int(os.environ.get("SMTP_PORT", "587"))
+    user = os.environ.get("SMTP_USER", "")
+    password = os.environ.get("SMTP_PASS", "")
+    from_addr = os.environ.get("SMTP_FROM", user or "agent@solvent.local")
+    msg = MIMEMultipart()
+    msg["From"] = from_addr
+    msg["To"] = to_email
+    msg["Subject"] = subject
+    msg.attach(MIMEText(body, "plain"))
+    with smtplib.SMTP(host, port, timeout=30) as server:
+        server.starttls()
+        if user and password:
+            server.login(user, password)
+        server.sendmail(from_addr, [to_email], msg.as_string())
+    return {"simulated": False, "to": to_email}

--- a/solvent/improver.py
+++ b/solvent/improver.py
@@ -1,0 +1,117 @@
+"""Auto-improvement loop: tune pricing and guardrails from job metrics."""
+
+from __future__ import annotations
+
+import json
+import time
+from pathlib import Path
+
+from .pricing import RESOURCE_COSTS_CENTS
+from .treasury import Treasury
+
+IMPROVEMENT_LOG = Path("data/improvement_log.jsonl")
+OVERRIDES_PATH = Path(".solvent/pricing_overrides.json")
+PROMPTS_DIR = Path(".solvent/prompts")
+
+
+def analyze_metrics(treasury: Treasury) -> dict:
+    metrics = treasury.list_metrics()
+    completed = [m for m in metrics if m.get("refunded", 0) == 0 and m.get("actual_cost_cents")]
+    if len(completed) < 5:
+        return {"ready": False, "reason": f"need 5+ completed jobs, have {len(completed)}"}
+    margin_errors = [
+        (m.get("actual_margin_pct") or 0) - (m.get("est_margin_pct") or 0)
+        for m in completed
+    ]
+    avg_margin_error = sum(margin_errors) / len(margin_errors)
+    refund_rate = sum(1 for m in metrics if m.get("refunded")) / max(len(metrics), 1)
+    fulfill_times = [m.get("fulfillment_seconds") or 0 for m in completed]
+    avg_fulfill = sum(fulfill_times) / len(fulfill_times) if fulfill_times else 0
+    return {
+        "ready": True,
+        "avg_margin_error": avg_margin_error,
+        "refund_rate": refund_rate,
+        "avg_fulfillment_seconds": avg_fulfill,
+        "sample_size": len(completed),
+    }
+
+
+def propose_changes(analysis: dict) -> list[dict]:
+    proposals: list[dict] = []
+    if not analysis.get("ready"):
+        return proposals
+    if analysis["avg_margin_error"] < -5:
+        current = RESOURCE_COSTS_CENTS["nemotron_tokens_per_1k"]
+        proposals.append({
+            "type": "pricing",
+            "key": "nemotron_tokens_per_1k",
+            "from": current,
+            "to": int(current * 1.05),
+            "reason": f"avg margin error {analysis['avg_margin_error']:.1f}%",
+        })
+    if analysis["refund_rate"] > 0.10:
+        proposals.append({
+            "type": "guardrail",
+            "key": "daily_budget_cents",
+            "action": "reduce_10pct",
+            "reason": f"refund rate {analysis['refund_rate']:.0%}",
+        })
+    if analysis["avg_fulfillment_seconds"] > 120:
+        proposals.append({
+            "type": "agent",
+            "key": "max_tool_rounds",
+            "action": "reduce_by_1",
+            "reason": f"avg fulfillment {analysis['avg_fulfillment_seconds']:.0f}s",
+        })
+    return proposals
+
+
+def apply_changes(proposals: list[dict]) -> list[dict]:
+    applied: list[dict] = []
+    OVERRIDES_PATH.parent.mkdir(parents=True, exist_ok=True)
+    overrides = {}
+    if OVERRIDES_PATH.is_file():
+        try:
+            overrides = json.loads(OVERRIDES_PATH.read_text(encoding="utf-8"))
+        except (json.JSONDecodeError, OSError):
+            overrides = {}
+    for p in proposals:
+        if p["type"] == "pricing":
+            overrides[p["key"]] = p["to"]
+            applied.append(p)
+    if overrides:
+        OVERRIDES_PATH.write_text(json.dumps(overrides, indent=2) + "\n", encoding="utf-8")
+    return applied
+
+
+def log_improvement(entry: dict) -> None:
+    IMPROVEMENT_LOG.parent.mkdir(parents=True, exist_ok=True)
+    entry["ts"] = time.time()
+    with IMPROVEMENT_LOG.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(entry) + "\n")
+
+
+def tune(treasury: Treasury | None = None, *, apply: bool = False) -> dict:
+    treasury = treasury or Treasury()
+    analysis = analyze_metrics(treasury)
+    proposals = propose_changes(analysis)
+    result = {"analysis": analysis, "proposals": proposals, "applied": []}
+    if apply and proposals:
+        result["applied"] = apply_changes(proposals)
+        log_improvement({"action": "apply", "proposals": proposals})
+    elif proposals:
+        log_improvement({"action": "dry_run", "proposals": proposals})
+    return result
+
+
+def main():
+    import argparse
+    parser = argparse.ArgumentParser(description="SOLVENT auto-improvement tuner")
+    parser.add_argument("--apply", action="store_true", help="apply proposed changes")
+    args = parser.parse_args()
+    result = tune(apply=args.apply)
+    print(json.dumps(result, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/solvent/nemotron.py
+++ b/solvent/nemotron.py
@@ -9,10 +9,12 @@ with zero credentials. Either way the rest of the system is identical.
 
 from __future__ import annotations
 
-import os
 import json
+import os
+import re
 import urllib.request
 
+from . import tools
 
 MODEL = os.environ.get("NEMOTRON_MODEL", "nvidia/llama-3.1-nemotron-ultra-253b-v1")
 ENDPOINT = "https://integrate.api.nvidia.com/v1/chat/completions"
@@ -28,7 +30,17 @@ def configure(model: str = "offline", nemotron_model: str | None = None) -> None
         MODEL = nemotron_model
 
 
-def _live_complete(system: str, user: str) -> str:
+def _estimate_tokens(system: str, user: str, text: str) -> dict:
+    total = max(1, (len(system) + len(user) + len(text)) // 4)
+    return {
+        "prompt_tokens": max(1, (len(system) + len(user)) // 4),
+        "completion_tokens": max(1, len(text) // 4),
+        "total_tokens": total,
+        "estimated": True,
+    }
+
+
+def _live_complete(system: str, user: str) -> tuple[str, dict]:
     key = os.environ["NVIDIA_API_KEY"]
     body = json.dumps({
         "model": MODEL,
@@ -45,7 +57,16 @@ def _live_complete(system: str, user: str) -> str:
     )
     with urllib.request.urlopen(req, timeout=60) as r:
         data = json.loads(r.read())
-    return data["choices"][0]["message"]["content"]
+    text = data["choices"][0]["message"]["content"]
+    usage = data.get("usage") or {}
+    if usage:
+        return text, {
+            "prompt_tokens": usage.get("prompt_tokens", 0),
+            "completion_tokens": usage.get("completion_tokens", 0),
+            "total_tokens": usage.get("total_tokens", 0),
+            "estimated": False,
+        }
+    return text, _estimate_tokens(system, user, text)
 
 
 def _stub_complete(system: str, user: str) -> str:
@@ -71,18 +92,72 @@ def _stub_complete(system: str, user: str) -> str:
     )
 
 
-def complete(system: str, user: str) -> tuple[str, int]:
-    """Return (text, tokens_used_estimate)."""
+def complete(system: str, user: str) -> tuple[str, dict]:
+    """Return (text, usage_dict). usage_dict has prompt/completion/total tokens."""
     if _force_offline:
         text = _stub_complete(system, user)
-        tokens = max(1, (len(system) + len(user) + len(text)) // 4)
-        return text, tokens
+        return text, _estimate_tokens(system, user, text)
     if os.environ.get("NVIDIA_API_KEY"):
         try:
-            text = _live_complete(system, user)
-        except Exception as e:  # network/key issues -> never break the demo
+            return _live_complete(system, user)
+        except Exception as e:
             text = _stub_complete(system, user) + f"\n\n<!-- live call failed: {e} -->"
-    else:
-        text = _stub_complete(system, user)
-    tokens = max(1, (len(system) + len(user) + len(text)) // 4)
-    return text, tokens
+            return text, _estimate_tokens(system, user, text)
+    text = _stub_complete(system, user)
+    return text, _estimate_tokens(system, user, text)
+
+
+_TOOL_CALL_RE = re.compile(
+    r"TOOL_CALL:\s*(\w+)\s*(\{.*?\})",
+    re.DOTALL,
+)
+
+
+def research_brief(topic: str, context: str = "n/a") -> tuple[str, dict, tools.ToolContext]:
+    """Bounded tool-calling loop: plan → tools → final brief."""
+    ctx = tools.ToolContext()
+    live_search = bool(os.environ.get("SOLVENT_LIVE_SEARCH", "").strip() in ("1", "true", "yes"))
+    notes: list[str] = []
+    system = (
+        "You are SOLVENT, a disciplined sell-side research analyst. "
+        "You may request tools using TOOL_CALL: tool_name {\"arg\": \"value\"}. "
+        "Allowed tools: web_search, market_data, summarize. "
+        "Do not request payment or treasury actions. "
+        "After gathering evidence, write the final brief with markdown headings."
+    )
+    user = f"Research topic: {topic}\nClient context: {context}\n\nBegin research."
+
+    for _round in range(tools.MAX_TOOL_ROUNDS):
+        text, usage = complete(system, user)
+        matches = list(_TOOL_CALL_RE.finditer(text))
+        if not matches:
+            if "# " in text or "## " in text:
+                return text, usage, ctx
+            user = text + "\n\nWrite the final research brief now with markdown headings."
+            continue
+        for m in matches:
+            name = m.group(1)
+            try:
+                args = json.loads(m.group(2))
+            except json.JSONDecodeError:
+                continue
+            if ctx.total_calls >= tools.MAX_TOOL_CALLS:
+                break
+            try:
+                result = tools.dispatch(
+                    name, args, ctx, lambda s, u: complete(s, u)[0], live_search=live_search
+                )
+                notes.append(f"### {name}\n{result}")
+            except (ValueError, RuntimeError):
+                continue
+        user = (
+            f"Research notes so far:\n" + "\n\n".join(notes) +
+            "\n\nWrite the final decision-ready research brief for: " + topic
+        )
+
+    final_user = (
+        f"Research notes:\n" + "\n\n".join(notes) +
+        f"\n\nProduce the final brief for: {topic}"
+    )
+    text, usage = complete(system, final_user)
+    return text, usage, ctx

--- a/solvent/observability.py
+++ b/solvent/observability.py
@@ -1,0 +1,53 @@
+"""Structured JSON logging and event persistence for SOLVENT."""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import time
+from pathlib import Path
+
+LOG_PATH = Path(__file__).resolve().parent.parent / "data" / "solvent.log"
+
+
+def log_event(
+    treasury,
+    *,
+    job_id: str,
+    stage: str,
+    stripe_ref: str | None = None,
+    margin_est: float | None = None,
+    margin_actual: float | None = None,
+    duration_ms: float | None = None,
+    simulated: bool | None = None,
+    **extra,
+) -> dict:
+    """Emit a structured log line and persist to treasury events table."""
+    record = {
+        "ts": time.time(),
+        "job_id": job_id,
+        "stage": stage,
+        "stripe_ref": stripe_ref,
+        "margin_est": margin_est,
+        "margin_actual": margin_actual,
+        "duration_ms": duration_ms,
+        "simulated": simulated,
+        **extra,
+    }
+    record = {k: v for k, v in record.items() if v is not None}
+    if treasury is not None:
+        try:
+            treasury.record_event(job_id, stage, record)
+        except Exception:
+            pass
+    if os.environ.get("SOLVENT_LOG_JSON", "").strip() in ("1", "true", "yes"):
+        line = json.dumps(record, default=str)
+        print(line, file=sys.stderr)
+    LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        with LOG_PATH.open("a", encoding="utf-8") as f:
+            f.write(json.dumps(record, default=str) + "\n")
+    except OSError:
+        pass
+    return record

--- a/solvent/pricing.py
+++ b/solvent/pricing.py
@@ -60,18 +60,27 @@ class PricingPolicy:
     min_price_cents: int = 1_500       # never sell a report under $15
 
 
+def get_resource_costs() -> Dict[str, int]:
+    """Return effective resource costs, applying improver overrides if present."""
+    from pathlib import Path
+    import json
+    costs = dict(RESOURCE_COSTS_CENTS)
+    override_path = Path(".solvent/pricing_overrides.json")
+    if override_path.is_file():
+        try:
+            overrides = json.loads(override_path.read_text(encoding="utf-8"))
+            if isinstance(overrides, dict):
+                for k, v in overrides.items():
+                    if k in costs and isinstance(v, (int, float)):
+                        costs[k] = int(v)
+        except (json.JSONDecodeError, OSError):
+            pass
+    return costs
+
+
 def estimate_cost(job: Dict[str, Any]) -> Tuple[int, Dict[str, int]]:
-    """Estimate fulfilment cost from the job's declared complexity.
-
-    Args:
-        job: A dictionary defining job specifications (e.g. est_tokens, market_data_calls).
-
-    Returns:
-        A tuple containing:
-            - The total estimated cost in cents.
-            - A dictionary breaking down costs by resource type.
-    """
-    costs = RESOURCE_COSTS_CENTS
+    """Estimate fulfilment cost from the job's declared complexity."""
+    costs = get_resource_costs()
     tokens_k = job.get("est_tokens", 8_000) / 1_000
     breakdown = {
         "nemotron_inference": round(tokens_k * costs["nemotron_tokens_per_1k"]),

--- a/solvent/queue.py
+++ b/solvent/queue.py
@@ -1,0 +1,29 @@
+"""SQLite-backed job queue helpers."""
+
+from __future__ import annotations
+
+from .treasury import Treasury
+
+WORKER_STATUSES = ("awaiting_payment", "in_progress", "paid_pending_fulfill", "pending_quote")
+
+
+def list_claimable(treasury: Treasury) -> list[dict]:
+    return treasury.list_jobs_by_status(list(WORKER_STATUSES))
+
+
+def resume_incomplete_jobs(treasury: Treasury) -> list[str]:
+    """Find jobs with revenue but no completed fulfill stage."""
+    resumed: list[str] = []
+    for job in treasury.list_jobs():
+        jid = job["id"]
+        status = job.get("status", "")
+        if status in ("completed", "failed"):
+            continue
+        if treasury.job_has_revenue(jid) and not treasury.stage_completed(jid, "fulfill"):
+            treasury.upsert_job(jid, "paid_pending_fulfill")
+            resumed.append(jid)
+        elif status == "in_progress" and not treasury.stage_completed(jid, "fulfill"):
+            resumed.append(jid)
+        elif status == "awaiting_payment" and treasury.get_checkout(jid):
+            resumed.append(jid)
+    return resumed

--- a/solvent/reconcile.py
+++ b/solvent/reconcile.py
@@ -1,0 +1,76 @@
+"""Reconcile Stripe payments against the SOLVENT treasury ledger."""
+
+from __future__ import annotations
+
+import os
+import sys
+from datetime import datetime, timedelta, timezone
+
+from .treasury import Treasury
+
+try:
+    import stripe as stripe_sdk
+    _HAS_STRIPE = True
+except Exception:
+    stripe_sdk = None
+    _HAS_STRIPE = False
+
+
+def reconcile(treasury: Treasury | None = None, since_days: int = 7) -> dict:
+    treasury = treasury or Treasury()
+    ledger_refs = set()
+    session_refs = set()
+    for e in treasury.entries:
+        if e.kind == "revenue":
+            if e.stripe_ref:
+                ledger_refs.add(e.stripe_ref)
+            if e.stripe_session_id:
+                session_refs.add(e.stripe_session_id)
+
+    report = {
+        "ledger_revenue_count": len(ledger_refs),
+        "unmatched_stripe": [],
+        "unmatched_ledger": list(ledger_refs),
+        "duplicates": [],
+        "drift": False,
+    }
+
+    key = os.environ.get("STRIPE_API_KEY", "")
+    if not key or not _HAS_STRIPE or key.startswith("sk_live_"):
+        report["mode"] = "ledger_only"
+        return report
+
+    stripe_sdk.api_key = key
+    since = int((datetime.now(timezone.utc) - timedelta(days=since_days)).timestamp())
+    stripe_pis: set[str] = set()
+    try:
+        for pi in stripe_sdk.PaymentIntent.list(created={"gte": since}, limit=100).auto_paging_iter():
+            if pi.status == "succeeded":
+                stripe_pis.add(pi.id)
+    except Exception as exc:
+        report["stripe_error"] = str(exc)
+        return report
+
+    unmatched_stripe = stripe_pis - ledger_refs
+    unmatched_ledger = ledger_refs - stripe_pis
+    report["unmatched_stripe"] = sorted(unmatched_stripe)
+    report["unmatched_ledger"] = sorted(unmatched_ledger)
+    report["drift"] = bool(unmatched_stripe or unmatched_ledger)
+    report["mode"] = "full"
+    return report
+
+
+def main():
+    import argparse
+    parser = argparse.ArgumentParser(description="SOLVENT Stripe reconciliation")
+    parser.add_argument("--since", default="7d", help="lookback e.g. 7d")
+    args = parser.parse_args()
+    days = int(args.since.replace("d", "")) if args.since.endswith("d") else 7
+    report = reconcile(since_days=days)
+    print(report)
+    if report.get("drift"):
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/solvent/security.py
+++ b/solvent/security.py
@@ -347,7 +347,7 @@ def validate_catalog_schema(catalog: dict) -> dict:
     Returns:
         A clean dict with only permitted keys.
     """
-    allowed = {"product_id", "price_ids", "cardholder_id"}
+    allowed = {"product_id", "price_ids", "prices", "cardholder_id"}
     clean: dict = {}
 
     if "product_id" in catalog:
@@ -355,12 +355,22 @@ def validate_catalog_schema(catalog: dict) -> dict:
         if re.match(r"^prod_[A-Za-z0-9]{1,50}$", pid):
             clean["product_id"] = pid
 
-    if "price_ids" in catalog and isinstance(catalog["price_ids"], dict):
+    def _clean_prices(raw_prices: dict) -> dict:
         clean_prices = {}
-        for k, v in catalog["price_ids"].items():
+        for k, v in raw_prices.items():
             if re.match(r"^\d{1,10}$", str(k)) and re.match(r"^price_[A-Za-z0-9]{1,50}$", str(v)):
                 clean_prices[str(k)] = str(v)
-        clean["price_ids"] = clean_prices
+        return clean_prices
+
+    if "price_ids" in catalog and isinstance(catalog["price_ids"], dict):
+        clean["price_ids"] = _clean_prices(catalog["price_ids"])
+    if "prices" in catalog and isinstance(catalog["prices"], dict):
+        clean["prices"] = _clean_prices(catalog["prices"])
+    # Normalise: stripe_client uses "prices"; legacy tests use "price_ids"
+    if "prices" not in clean and "price_ids" in clean:
+        clean["prices"] = clean["price_ids"]
+    elif "price_ids" not in clean and "prices" in clean:
+        clean["price_ids"] = clean["prices"]
 
     if "cardholder_id" in catalog:
         cid = str(catalog["cardholder_id"])

--- a/solvent/server.py
+++ b/solvent/server.py
@@ -1,0 +1,96 @@
+"""HTTP server: Stripe webhooks, job API, hosted briefs."""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+from .agent import Solvent
+from .delivery import verify_delivery_token, markdown_to_html
+from .stripe_client import StripeClient
+
+
+def _require_fastapi():
+    try:
+        from fastapi import FastAPI, Request, HTTPException
+        from fastapi.responses import HTMLResponse, JSONResponse
+        return FastAPI, Request, HTTPException, HTMLResponse, JSONResponse
+    except ImportError as exc:
+        raise RuntimeError(
+            "FastAPI is required for `solvent serve`. "
+            "Install with: pip install -r requirements-serve.txt"
+        ) from exc
+
+
+def create_app(seed_cents: int = 10_000, fresh: bool = False) -> object:
+    FastAPI, Request, HTTPException, HTMLResponse, JSONResponse = _require_fastapi()
+    agent = Solvent(seed_cents=seed_cents, fresh=fresh, sync_payment=False)
+    stripe = StripeClient()
+    app = FastAPI(title="SOLVENT", version="2.0")
+
+    @app.get("/health")
+    def health():
+        return {"status": "ok", "balance_cents": agent.t.balance_cents()}
+
+    @app.post("/jobs")
+    async def create_job(request: Request):
+        body = await request.json()
+        if not body.get("id"):
+            import uuid
+            body["id"] = "J" + uuid.uuid4().hex[:8]
+        result = agent.enqueue_job(body)
+        return JSONResponse(result)
+
+    @app.get("/jobs/{job_id}")
+    def get_job(job_id: str):
+        row = agent.t.get_job(job_id)
+        if not row:
+            raise HTTPException(404, "job not found")
+        metrics = agent.t.get_metrics(job_id)
+        return {"job": dict(row), "metrics": metrics}
+
+    @app.post("/webhooks/stripe")
+    async def stripe_webhook(request: Request):
+        payload = await request.body()
+        sig = request.headers.get("Stripe-Signature", "")
+        payment = stripe.process_webhook(payload, sig, treasury=agent.t)
+        if payment and payment.get("job_id"):
+            agent._runner.handle_webhook_payment(payment)
+        return {"received": True}
+
+    @app.get("/briefs/{job_id}")
+    def get_brief(job_id: str, token: str = ""):
+        if not verify_delivery_token(job_id, token):
+            raise HTTPException(403, "invalid or expired delivery token")
+        path = Path(__file__).resolve().parent.parent / "data" / "reports" / f"{job_id}.md"
+        if not path.is_file():
+            for p in (Path(__file__).resolve().parent.parent / "data" / "reports").glob("*.md"):
+                if job_id in p.stem:
+                    path = p
+                    break
+        if not path.is_file():
+            raise HTTPException(404, "brief not found")
+        return HTMLResponse(markdown_to_html(path.read_text(encoding="utf-8")))
+
+    return app
+
+
+def main():
+    import argparse
+    parser = argparse.ArgumentParser(description="SOLVENT HTTP server")
+    parser.add_argument("--port", type=int, default=int(os.environ.get("SOLVENT_PORT", "8787")))
+    parser.add_argument("--host", default="127.0.0.1")
+    parser.add_argument("--seed", type=float, default=100.0)
+    parser.add_argument("--keep-balance", action="store_true")
+    args = parser.parse_args()
+    try:
+        import uvicorn
+    except ImportError as exc:
+        raise RuntimeError("uvicorn required: pip install -r requirements-serve.txt") from exc
+    app = create_app(seed_cents=int(args.seed * 100), fresh=not args.keep_balance)
+    uvicorn.run(app, host=args.host, port=args.port)
+
+
+if __name__ == "__main__":
+    main()

--- a/solvent/service.py
+++ b/solvent/service.py
@@ -9,25 +9,51 @@ Stripe on the SPEND side. This is what ties COGS to each unit of revenue.
 
 from __future__ import annotations
 
+import time
 from pathlib import Path
+
 from . import nemotron
-from .pricing import RESOURCE_COSTS_CENTS
+from .pricing import RESOURCE_COSTS_CENTS, get_resource_costs
 from .security import sanitise_prompt_input, safe_report_path, PromptInjectionError, InputValidationError
 
 OUTPUT_DIR = Path(__file__).resolve().parent.parent / "data" / "reports"
 
 
-def fulfill(job: dict) -> dict:
-    """Produce the report and return {deliverable_path, text, resources_used}.
+def _resources_from_usage(
+    usage: dict,
+    tool_ctx,
+    *,
+    include_delivery: bool = True,
+) -> list[tuple[str, int, str]]:
+    costs = get_resource_costs()
+    tokens = usage.get("total_tokens", 0)
+    resources = [
+        (
+            "nvidia-nemotron",
+            round((tokens / 1000) * costs["nemotron_tokens_per_1k"]),
+            f"Nemotron inference ({tokens} tokens)",
+        ),
+        (
+            "market-data-api",
+            tool_ctx.market_data_calls * costs["market_data_call"],
+            f"{tool_ctx.market_data_calls} market-data pulls",
+        ),
+        (
+            "web-search-api",
+            tool_ctx.web_search_calls * costs["web_search_call"],
+            f"{tool_ctx.web_search_calls} web searches",
+        ),
+        ("pdf-render-saas", costs["pdf_render"], "Render brief to PDF"),
+    ]
+    if include_delivery:
+        resources.append(
+            ("email-delivery-saas", costs["email_send"], "Deliver to customer")
+        )
+    return resources
 
-    Security:
-    - topic and context are sanitised for LLM prompt injection before the
-      Nemotron call (raises PromptInjectionError / InputValidationError on
-      detected attacks).
-    - The output file path is validated against OUTPUT_DIR to prevent path
-      traversal via a crafted job ID.
-    """
-    # PROMPT INJECTION — sanitise all untrusted strings before they enter the LLM
+
+def fulfill(job: dict) -> dict:
+    """Produce the report and return deliverable metadata + resources_used."""
     try:
         topic = sanitise_prompt_input(job.get("topic", ""), field_name="topic", max_len=500)
         context = sanitise_prompt_input(
@@ -36,31 +62,45 @@ def fulfill(job: dict) -> dict:
     except (PromptInjectionError, InputValidationError) as exc:
         raise ValueError(f"job input rejected by security layer: {exc}") from exc
 
-    system = (
-        "You are SOLVENT, a disciplined sell-side research analyst. Produce a "
-        "concise, decision-ready brief. Be specific and flag uncertainty."
-    )
-    user = f"{topic}\n\nClient context: {context}"
+    started = time.time()
+    text, usage, tool_ctx = nemotron.research_brief(topic, context)
+    fulfillment_seconds = time.time() - started
 
-    text, tokens = nemotron.complete(system, user)
-
-    # Itemize the resources this job actually consumed.
-    resources = [
-        ("nvidia-nemotron", round((tokens / 1000) * RESOURCE_COSTS_CENTS["nemotron_tokens_per_1k"]),
-         f"Nemotron inference ({tokens} tokens)"),
-        ("market-data-api", job.get("market_data_calls", 2) * RESOURCE_COSTS_CENTS["market_data_call"],
-         f"{job.get('market_data_calls', 2)} market-data pulls"),
-        ("web-search-api", job.get("web_search_calls", 6) * RESOURCE_COSTS_CENTS["web_search_call"],
-         f"{job.get('web_search_calls', 6)} web searches"),
-        ("pdf-render-saas", RESOURCE_COSTS_CENTS["pdf_render"], "Render brief to PDF"),
-        ("email-delivery-saas", RESOURCE_COSTS_CENTS["email_send"], "Deliver to customer"),
-    ]
+    resources = _resources_from_usage(usage, tool_ctx)
+    actual_cost = sum(r[1] for r in resources)
 
     OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
-
-    # PATH TRAVERSAL — validate job ID before using it as a filename
     path = safe_report_path(OUTPUT_DIR, job["id"])
     path.write_text(text)
 
-    return {"deliverable_path": str(path), "text": text, "resources_used": resources, "tokens": tokens}
+    return {
+        "deliverable_path": str(path),
+        "text": text,
+        "resources_used": resources,
+        "tokens": usage.get("total_tokens", 0),
+        "usage": usage,
+        "tool_ctx": tool_ctx,
+        "actual_cost_cents": actual_cost,
+        "fulfillment_seconds": fulfillment_seconds,
+    }
 
+
+def reconcile_cogs(quote, result: dict) -> dict:
+    """Compare estimated vs actual COGS after fulfillment."""
+    actual = result.get("actual_cost_cents", 0)
+    est = quote.est_cost_cents
+    price = quote.price_cents
+    actual_margin = price - actual
+    actual_margin_pct = round(100 * actual_margin / price, 1) if price else 0.0
+    drift = actual - est
+    warning = drift > est * 0.15 if est > 0 else False
+    return {
+        "est_cost_cents": est,
+        "actual_cost_cents": actual,
+        "est_margin_pct": quote.margin_pct,
+        "actual_margin_pct": actual_margin_pct,
+        "margin_drift_cents": drift,
+        "cost_warning": warning,
+        "fulfillment_seconds": result.get("fulfillment_seconds", 0),
+        "tool_calls": result.get("tool_ctx").total_calls if result.get("tool_ctx") else 0,
+    }

--- a/solvent/stages.py
+++ b/solvent/stages.py
@@ -1,0 +1,458 @@
+"""Idempotent job stage handlers for the SOLVENT money loop."""
+
+from __future__ import annotations
+
+import json
+import os
+import time
+from dataclasses import asdict
+
+from .treasury import Treasury
+from .guardrails import Guardrails, GuardrailError
+from .pricing import quote, PricingPolicy
+from .stripe_client import StripeClient
+from .security import sanitise_job, SOLVENTSecurityError
+from . import service, delivery
+from .observability import log_event
+
+
+def _base_url() -> str:
+    return os.environ.get("SOLVENT_BASE_URL", "http://127.0.0.1:8787").rstrip("/")
+
+
+def validate_and_coerce_job(job: dict, treasury: Treasury) -> tuple[dict | None, str | None]:
+    """Return (coerced_job, error_reason)."""
+    if not isinstance(job, dict):
+        return None, "job must be a dictionary"
+    job_id = job.get("id")
+    if not job_id or not isinstance(job_id, str):
+        return None, "missing or invalid job ID"
+    try:
+        job = dict(job)
+        sanitise_job(job)
+    except SOLVENTSecurityError as exc:
+        treasury.upsert_job(job_id, "failed", error_reason=str(exc))
+        return None, f"security violation: {exc}"
+
+    topic = job.get("topic")
+    if not topic or not isinstance(topic, str) or not topic.strip():
+        treasury.upsert_job(job_id, "failed", error_reason="missing or blank topic")
+        return None, "missing or blank topic"
+
+    budget_cents = job.get("budget_cents")
+    if budget_cents is None:
+        treasury.upsert_job(job_id, "failed", error_reason="missing budget_cents")
+        return None, "missing budget_cents"
+    try:
+        budget_cents = int(float(budget_cents))
+        if budget_cents < 0 or budget_cents > 1_000_000:
+            treasury.upsert_job(job_id, "failed", error_reason="invalid budget")
+            return None, "invalid budget"
+        job["budget_cents"] = budget_cents
+    except (ValueError, TypeError):
+        treasury.upsert_job(job_id, "failed", error_reason="budget_cents must be numeric")
+        return None, "budget_cents must be a valid numeric value"
+
+    for param, default_val in [("est_tokens", 8_000), ("market_data_calls", 2), ("web_search_calls", 6)]:
+        val = job.get(param)
+        if val is None:
+            val = default_val
+        try:
+            val = int(float(val))
+            if val < 0:
+                return None, f"{param} cannot be negative"
+            if param == "est_tokens" and val > 100_000:
+                return None, "est_tokens exceeds maximum limit"
+            if param in ("market_data_calls", "web_search_calls") and val > 50:
+                return None, f"{param} exceeds maximum limit"
+            job[param] = val
+        except (ValueError, TypeError):
+            return None, f"{param} must be a valid numeric value"
+
+    job.setdefault("customer_email", "client@example.com")
+    treasury.upsert_job(
+        job_id,
+        "pending_quote",
+        topic=job["topic"],
+        budget_cents=job["budget_cents"],
+        customer_email=job["customer_email"],
+        est_tokens=job["est_tokens"],
+        market_data_calls=job["market_data_calls"],
+        web_search_calls=job["web_search_calls"],
+        job_payload_json=job,
+    )
+    return job, None
+
+
+class StageRunner:
+    """Runs idempotent stages for a single job."""
+
+    def __init__(
+        self,
+        treasury: Treasury,
+        guard: Guardrails,
+        stripe: StripeClient,
+        pricing: PricingPolicy | None = None,
+        on_event: callable | None = None,
+        *,
+        sync_payment: bool = True,
+    ):
+        self.t = treasury
+        self.guard = guard
+        self.stripe = stripe
+        self.pricing = pricing or PricingPolicy()
+        self.on_event = on_event
+        self.sync_payment = sync_payment
+
+    def _emit(self, **event):
+        if "ts" not in event:
+            event["ts"] = time.time()
+        if self.on_event:
+            self.on_event(event)
+        log_event(
+            self.t,
+            job_id=event.get("job_id", ""),
+            stage=event.get("stage", ""),
+            stripe_ref=event.get("payment_intent") or event.get("stripe_ref"),
+            margin_est=event.get("margin_pct"),
+            margin_actual=event.get("actual_margin_pct"),
+            simulated=event.get("simulated"),
+            **{k: v for k, v in event.items() if k not in ("job_id", "stage", "simulated", "payment_intent", "stripe_ref", "margin_pct", "actual_margin_pct")},
+        )
+        try:
+            from . import dashboard
+            dashboard.render(self.t.snapshot(), [])
+        except Exception:
+            pass
+        return event
+
+    def run_job(self, job: dict) -> dict:
+        job, err = validate_and_coerce_job(job, self.t)
+        if err:
+            return self._emit(stage="declined", job_id=job.get("id", "unknown") if job else "unknown", reason=err)
+
+        job_id = job["id"]
+        q = self._stage_quote(job)
+        if q.get("stage") == "declined" or not q.get("accept"):
+            return q
+
+        quote_obj = q.get("_quote") or quote(job, self.pricing)
+        checkout = self._stage_checkout(job, q)
+        if checkout.get("stage") == "payment_pending":
+            return checkout
+
+        paid = self._stage_paid(job, checkout, quote_obj)
+        if paid.get("stage") == "payment_pending":
+            return paid
+
+        return self._stage_fulfill_and_book(job, quote_obj, paid)
+
+    def advance_job(self, job_id: str) -> dict:
+        """Resume a job from its current DB state."""
+        row = self.t.get_job(job_id)
+        if not row:
+            return self._emit(stage="declined", job_id=job_id, reason="job not found")
+        payload = row.get("job_payload_json")
+        if isinstance(payload, str):
+            job = json.loads(payload)
+        else:
+            job = {
+                "id": job_id,
+                "topic": row.get("topic"),
+                "budget_cents": row.get("budget_cents"),
+                "customer_email": row.get("customer_email"),
+                "est_tokens": row.get("est_tokens"),
+                "market_data_calls": row.get("market_data_calls"),
+                "web_search_calls": row.get("web_search_calls"),
+            }
+        status = row.get("status", "")
+        if status in ("completed", "failed"):
+            return self._emit(stage="booked", job_id=job_id, status=status, job_pnl=self.t.job_pnl_cents(job_id))
+        if status == "pending_quote" or not row.get("quote_json"):
+            return self.run_job(job)
+        q_data = json.loads(row["quote_json"])
+        q = type("Q", (), q_data)()
+        if status == "awaiting_payment":
+            checkout = {
+                "session_id": row.get("checkout_session_id"),
+                "url": row.get("checkout_url"),
+                "amount_cents": q_data.get("price_cents"),
+            }
+            from .pricing import Quote
+            quote_obj = Quote(**{k: q_data[k] for k in q_data if k in Quote.__dataclass_fields__})
+            paid = self._stage_paid(job, checkout, quote_obj)
+            if paid.get("stage") == "payment_pending":
+                return paid
+            return self._stage_fulfill_and_book(job, quote_obj, paid)
+        if status in ("in_progress", "paid_pending_fulfill"):
+            from .pricing import Quote
+            quote_obj = Quote(**{k: q_data[k] for k in q_data if k in Quote.__dataclass_fields__})
+            paid = {"stripe_ref": None, "amount_cents": q_data.get("price_cents")}
+            rev = self.t.entries
+            for e in rev:
+                if e.job_id == job_id and e.kind == "revenue":
+                    paid["stripe_ref"] = e.stripe_ref
+                    paid["amount_cents"] = e.amount_cents
+                    break
+            return self._stage_fulfill_and_book(job, quote_obj, paid)
+        return self.run_job(job)
+
+    def _stage_quote(self, job: dict) -> dict:
+        job_id = job["id"]
+        key = f"quote:{job_id}"
+        cached = self.t.get_stage(key)
+        if cached and cached["status"] == "completed":
+            data = json.loads(cached["result_json"] or "{}")
+            return self._emit(stage="quote", job_id=job_id, **data)
+
+        q = quote(job, self.pricing)
+        result = {
+            "price": q.price_cents,
+            "est_cost": q.est_cost_cents,
+            "margin_pct": q.margin_pct,
+            "accept": q.accept,
+            "reason": q.reason,
+        }
+        self.t.complete_stage(job_id, "quote", key, result, payload={"job_id": job_id})
+        self.t.upsert_job(job_id, "pending_quote" if q.accept else "failed", quote_json=json.dumps(asdict(q)))
+        self._emit(stage="quote", job_id=job_id, title=job["topic"], **result)
+        if not q.accept:
+            self.t.upsert_job(job_id, "failed", error_reason=q.reason)
+            self.t.upsert_metrics(job_id, decline_reason=q.reason, est_cost_cents=q.est_cost_cents)
+            return self._emit(stage="declined", job_id=job_id, reason=q.reason)
+
+        with self.t.lock():
+            if self.guard._spent_last_24h() + q.est_cost_cents > self.guard.policy.daily_budget_cents:
+                reason = "fulfilment cost would exceed 24h spend budget limit"
+                self.t.upsert_job(job_id, "failed", error_reason=reason)
+                return self._emit(stage="declined", job_id=job_id, reason=reason)
+            projected = self.t.balance_cents() + q.price_cents - q.est_cost_cents
+            if projected < self.guard.policy.min_reserve_cents:
+                reason = "fulfilment would breach minimum cash reserve limit"
+                self.t.upsert_job(job_id, "failed", error_reason=reason)
+                return self._emit(stage="declined", job_id=job_id, reason=reason)
+        return {**result, "accept": True, "_quote": q}
+
+    def _stage_checkout(self, job: dict, q_result: dict) -> dict:
+        job_id = job["id"]
+        q = q_result.get("_quote") or quote(job, self.pricing)
+        key = f"checkout:{job_id}"
+        cached = self.t.get_stage(key)
+        if cached and cached["status"] == "completed":
+            return json.loads(cached["result_json"] or "{}")
+
+        self.t.upsert_job(job_id, "awaiting_payment", current_stage="checkout")
+        base = _base_url()
+        success = delivery.hosted_brief_url(base, job_id)
+        cancel = f"{base}/jobs/{job_id}?cancelled=1"
+
+        session = self.stripe.create_checkout_session(
+            job_id=job_id,
+            amount_cents=q.price_cents,
+            customer_email=job.get("customer_email", "client@example.com"),
+            name=f"Research brief: {job['topic'][:60]}",
+            success_url=success + "&paid=1",
+            cancel_url=cancel,
+        )
+        result = {
+            "session_id": session["id"],
+            "url": session["url"],
+            "amount_cents": q.price_cents,
+            "simulated": session.get("simulated", False),
+        }
+        self.t.complete_stage(job_id, "checkout", key, result)
+        self.t.upsert_checkout(job_id, session["id"], session["url"], "open")
+        self.t.upsert_job(
+            job_id,
+            "awaiting_payment",
+            checkout_session_id=session["id"],
+            checkout_url=session["url"],
+            current_stage="awaiting_payment",
+        )
+        self._emit(stage="invoice", job_id=job_id, url=session["url"], amount=q.price_cents, simulated=result["simulated"])
+        return result
+
+    def _stage_paid(self, job: dict, checkout: dict, q) -> dict:
+        job_id = job["id"]
+        session_id = checkout.get("session_id") or checkout.get("id", "")
+        key = f"paid:{job_id}:{session_id}"
+        cached = self.t.get_stage(key)
+        if cached and cached["status"] == "completed":
+            return json.loads(cached["result_json"] or "{}")
+
+        if self.t.job_has_revenue(job_id):
+            for e in self.t.entries:
+                if e.job_id == job_id and e.kind == "revenue":
+                    result = {
+                        "paid": True,
+                        "stripe_ref": e.stripe_ref,
+                        "checkout_session_id": e.stripe_session_id,
+                        "amount_cents": e.amount_cents,
+                    }
+                    return result
+
+        link = {
+            "id": session_id,
+            "url": checkout.get("url"),
+            "amount_cents": checkout.get("amount_cents", getattr(q, "price_cents", 0)),
+            "simulated": checkout.get("simulated", False),
+            "job_id": job_id,
+        }
+        if self.sync_payment:
+            payment = self.stripe.confirm_payment(link, job_id=job_id)
+        else:
+            payment = self.stripe.get_cached_payment(job_id) or {"paid": False, "reason": "awaiting webhook"}
+
+        if not payment.get("paid"):
+            reason = payment.get("reason", "payment not received")
+            self.t.upsert_job(job_id, "awaiting_payment", error_reason=reason)
+            return self._emit(
+                stage="payment_pending",
+                job_id=job_id,
+                reason=reason,
+                url=checkout.get("url"),
+            )
+
+        with self.t.lock():
+            self.t.earn(
+                payment["amount_cents"],
+                f"Payment for {job_id}",
+                job_id=job_id,
+                stripe_ref=payment["stripe_ref"],
+                stripe_session_id=payment.get("checkout_session_id"),
+                stripe_link_id=payment.get("payment_link_id"),
+            )
+        result = {
+            "paid": True,
+            "stripe_ref": payment["stripe_ref"],
+            "checkout_session_id": payment.get("checkout_session_id"),
+            "amount_cents": payment["amount_cents"],
+        }
+        self.t.complete_stage(job_id, "paid", key, result)
+        self.t.upsert_job(job_id, "paid_pending_fulfill", current_stage="paid")
+        self.t.upsert_checkout(job_id, session_id, checkout.get("url", ""), "paid")
+        self._emit(
+            stage="paid",
+            job_id=job_id,
+            amount=payment["amount_cents"],
+            payment_intent=payment["stripe_ref"],
+            checkout_session=payment.get("checkout_session_id"),
+        )
+        return result
+
+    def _stage_fulfill_and_book(self, job: dict, q, paid: dict) -> dict:
+        job_id = job["id"]
+        payment_intent_id = paid.get("stripe_ref")
+        paid_amount = paid.get("amount_cents", getattr(q, "price_cents", 0))
+        self.t.upsert_job(job_id, "in_progress", current_stage="fulfill")
+
+        try:
+            fulfill_key = f"fulfill:{job_id}"
+            if self.t.get_stage(fulfill_key) and self.t.get_stage(fulfill_key)["status"] == "completed":
+                result = json.loads(self.t.get_stage(fulfill_key)["result_json"] or "{}")
+            else:
+                result = service.fulfill(job)
+                self.t.complete_stage(job_id, "fulfill", fulfill_key, {
+                    "deliverable_path": result["deliverable_path"],
+                    "tokens": result["tokens"],
+                })
+            self._emit(
+                stage="fulfilled",
+                job_id=job_id,
+                deliverable=result["deliverable_path"],
+                tokens=result.get("tokens", 0),
+            )
+
+            cogs = service.reconcile_cogs(q, result)
+            self.t.upsert_metrics(
+                job_id,
+                est_cost_cents=cogs["est_cost_cents"],
+                actual_cost_cents=cogs["actual_cost_cents"],
+                est_margin_pct=cogs["est_margin_pct"],
+                actual_margin_pct=cogs["actual_margin_pct"],
+                margin_drift_cents=cogs["margin_drift_cents"],
+                fulfillment_seconds=cogs["fulfillment_seconds"],
+                tool_calls=cogs["tool_calls"],
+                refunded=0,
+            )
+            self._emit(stage="cogs_reconciled", job_id=job_id, **cogs)
+
+            deliver_key = f"deliver:{job_id}"
+            if not (self.t.get_stage(deliver_key) and self.t.get_stage(deliver_key)["status"] == "completed"):
+                hosted = delivery.hosted_brief_url(_base_url(), job_id)
+                from pathlib import Path
+                delivery.send_brief_email(
+                    job.get("customer_email", "client@example.com"),
+                    job_id,
+                    Path(result["deliverable_path"]),
+                    hosted,
+                )
+                self.t.complete_stage(job_id, "deliver", deliver_key, {"hosted_url": hosted})
+                self.t.upsert_job(job_id, "in_progress", deliverable_url=hosted, current_stage="deliver")
+                self._emit(stage="delivered", job_id=job_id, url=hosted)
+
+            job_margin = getattr(q, "margin_cents", q.price_cents - q.est_cost_cents)
+            for vendor, amount, memo in result.get("resources_used", []):
+                if amount <= 0:
+                    continue
+                spend_key = f"spend:{job_id}:{vendor}"
+                if self.t.get_stage(spend_key) and self.t.get_stage(spend_key)["status"] == "completed":
+                    continue
+                with self.t.lock():
+                    if not self.guard.approve(amount, vendor, projected_job_margin_cents=job_margin):
+                        self._emit(stage="spend_blocked", job_id=job_id, vendor=vendor, amount=amount, memo=memo)
+                        raise GuardrailError(f"spend to {vendor} of {amount}c rejected by guardrails")
+                    pay = self.stripe.pay_vendor(vendor, amount, memo)
+                    self.t.spend(amount, memo, job_id=job_id, vendor=vendor, stripe_ref=pay["id"])
+                    self.t.complete_stage(job_id, "spend", spend_key, {"vendor": vendor, "amount": amount})
+                    self._emit(stage="spend", job_id=job_id, vendor=vendor, amount=amount, memo=memo)
+
+            self.t.upsert_job(job_id, "completed", current_stage="booked")
+            pnl = self.t.job_pnl_cents(job_id)
+            return self._emit(
+                stage="booked",
+                job_id=job_id,
+                job_pnl=pnl,
+                balance=self.t.balance_cents(),
+                status="completed",
+                actual_margin_pct=cogs["actual_margin_pct"],
+            )
+        except Exception as e:
+            reason = str(e)
+            refund_key = f"refund:{job_id}:{payment_intent_id}"
+            if payment_intent_id and not (
+                self.t.get_stage(refund_key) and self.t.get_stage(refund_key)["status"] == "completed"
+            ):
+                refund = self.stripe.refund_payment(payment_intent_id, paid_amount, job_id=job_id)
+                self.t.spend(
+                    amount_cents=paid_amount,
+                    memo=f"Refund for job {job_id} due to block/failure: {reason}",
+                    job_id=job_id,
+                    stripe_ref=refund["id"],
+                )
+                self.t.complete_stage(job_id, "refund", refund_key, {"refund_id": refund["id"]})
+            self.t.upsert_metrics(job_id, refunded=1)
+            self._emit(stage="refunded", job_id=job_id, amount=paid_amount, reason=reason)
+            self.t.upsert_job(job_id, "failed", error_reason=reason, current_stage="failed")
+            pnl = self.t.job_pnl_cents(job_id)
+            return self._emit(
+                stage="booked",
+                job_id=job_id,
+                job_pnl=pnl,
+                balance=self.t.balance_cents(),
+                status="failed",
+            )
+
+    def handle_webhook_payment(self, payment: dict) -> dict | None:
+        """Apply a verified webhook payment and advance the job."""
+        job_id = payment.get("job_id")
+        if not job_id:
+            return None
+        session_id = payment.get("checkout_session_id", "")
+        key = f"paid:{job_id}:{session_id}"
+        if self.t.get_stage(key) and self.t.get_stage(key)["status"] == "completed":
+            return self.advance_job(job_id)
+        row = self.t.get_job(job_id)
+        if not row:
+            return None
+        return self.advance_job(job_id)

--- a/solvent/stripe_client.py
+++ b/solvent/stripe_client.py
@@ -141,7 +141,7 @@ class StripeClient:
         self._webhook_payments[plink_id] = payment
         self._save_webhook_cache()
 
-    def process_webhook(self, payload: bytes, sig_header: str) -> dict | None:
+    def process_webhook(self, payload: bytes, sig_header: str, treasury=None) -> dict | None:
         """Validate checkout.session.completed and cache verified payment.
 
         AUTH: signature is verified with HMAC-SHA256 before any data is read.
@@ -150,29 +150,100 @@ class StripeClient:
         if not self.live or not self.webhook_secret:
             return None
 
-        # 1. Verify Stripe-Signature header (raises WebhookAuthError if invalid)
         verify_webhook_signature(payload, sig_header, self.webhook_secret)
-
-        # 2. Parse event using the Stripe SDK for structural validation
         event = stripe.Webhook.construct_event(payload, sig_header, self.webhook_secret)
-
-        # 3. Replay protection — reject duplicate event IDs
         event_id = event.get("id", "")
-        check_event_replay(event_id)  # raises ReplayAttackError if duplicate
+        check_event_replay(event_id)
 
         if event["type"] != "checkout.session.completed":
             return None
         session = event["data"]["object"]
         if session.get("payment_status") != "paid":
             return None
-        plink_id = session.get("payment_link")
-        if not plink_id:
-            return None
         payment = self._session_to_payment(session)
-        self._cache_webhook_payment(plink_id, payment)
+        job_id = None
+        metadata = session.get("metadata") or {}
+        if isinstance(metadata, dict):
+            job_id = metadata.get("job_id")
+        if not job_id:
+            job_id = session.get("client_reference_id")
+        payment["job_id"] = job_id
+
+        plink_id = session.get("payment_link")
+        if plink_id:
+            self._cache_webhook_payment(plink_id, payment)
+        if job_id:
+            self._cache_webhook_payment(f"job:{job_id}", payment)
+            if treasury is not None:
+                try:
+                    treasury.upsert_checkout(
+                        job_id,
+                        payment.get("checkout_session_id", ""),
+                        "",
+                        "paid",
+                    )
+                except Exception:
+                    pass
         return payment
 
+    def get_cached_payment(self, job_id: str) -> dict | None:
+        cached = self._webhook_payments.get(f"job:{job_id}")
+        if cached and cached.get("paid"):
+            return cached
+        return None
+
     # ---- EARN -------------------------------------------------------
+    def create_checkout_session(
+        self,
+        job_id: str,
+        amount_cents: int,
+        customer_email: str,
+        name: str,
+        success_url: str,
+        cancel_url: str,
+    ) -> dict:
+        """Create a Stripe Checkout Session (primary) or simulate one."""
+        try:
+            customer_email = validate_email(customer_email)
+        except Exception:
+            customer_email = "client@example.com"
+        if self.live:
+            session = stripe.checkout.Session.create(
+                mode="payment",
+                line_items=[{
+                    "price_data": {
+                        "currency": "usd",
+                        "unit_amount": amount_cents,
+                        "product_data": {"name": name[:500]},
+                    },
+                    "quantity": 1,
+                }],
+                metadata={
+                    "job_id": job_id,
+                    "customer_email": customer_email,
+                    "agent": "SOLVENT",
+                },
+                client_reference_id=job_id,
+                success_url=success_url,
+                cancel_url=cancel_url,
+                idempotency_key=f"checkout-{job_id}",
+            )
+            return {
+                "id": session.id,
+                "url": session.url,
+                "amount_cents": amount_cents,
+                "simulated": False,
+                "job_id": job_id,
+            }
+        ref = "cs_sim_" + uuid.uuid4().hex[:12]
+        return {
+            "id": ref,
+            "url": f"https://checkout.stripe.test/{ref}",
+            "amount_cents": amount_cents,
+            "simulated": True,
+            "job_id": job_id,
+        }
+
     def create_payment_link(self, name: str, amount_cents: int, customer_email: str) -> dict:
         """Create a real Stripe Payment Link (test mode) or simulate one."""
         # ACCOUNT TAKEOVER — validate email before it reaches Stripe or the ledger
@@ -205,12 +276,46 @@ class StripeClient:
         if hasattr(pi_id, "id"):
             pi_id = pi_id.id
         amount = session.get("amount_total") if isinstance(session, dict) else session.amount_total
+        metadata = session.get("metadata") if isinstance(session, dict) else getattr(session, "metadata", {}) or {}
+        job_id = metadata.get("job_id") if isinstance(metadata, dict) else None
+        if not job_id:
+            job_id = session.get("client_reference_id") if isinstance(session, dict) else getattr(session, "client_reference_id", None)
         return {
             "paid": True,
             "stripe_ref": pi_id,
             "checkout_session_id": session.get("id") if isinstance(session, dict) else session.id,
             "payment_link_id": session.get("payment_link") if isinstance(session, dict) else session.payment_link,
             "amount_cents": amount,
+            "job_id": job_id,
+            "ts": time.time(),
+        }
+
+    def _poll_checkout_session_by_id(self, session_id: str, link: dict) -> dict:
+        deadline = time.time() + self.poll_timeout
+        job_id = link.get("job_id")
+        while time.time() < deadline:
+            if job_id and f"job:{job_id}" in self._webhook_payments:
+                cached = self._webhook_payments[f"job:{job_id}"]
+                if cached.get("paid"):
+                    return cached
+            if self.webhook_secret and session_id in self._webhook_payments:
+                cached = self._webhook_payments[session_id]
+                if cached.get("paid"):
+                    return cached
+            try:
+                session = stripe.checkout.Session.retrieve(session_id)
+                if session.payment_status == "paid":
+                    payment = self._session_to_payment(session)
+                    if not payment.get("amount_cents"):
+                        payment["amount_cents"] = link["amount_cents"]
+                    return payment
+            except Exception:
+                pass
+            time.sleep(self.poll_interval)
+        return {
+            "paid": False,
+            "reason": f"payment not received within {int(self.poll_timeout)}s",
+            "amount_cents": link["amount_cents"],
             "ts": time.time(),
         }
 
@@ -238,29 +343,45 @@ class StripeClient:
             "ts": time.time(),
         }
 
-    def confirm_payment(self, link: dict) -> dict:
+    def confirm_payment(self, link: dict, job_id: str | None = None) -> dict:
         """Verify payment before fulfilment.
 
         Simulate mode: instant confirm (demo / offline).
-        Live mode: poll Checkout Sessions until paid, or use webhook cache when
-        STRIPE_WEBHOOK_SECRET is set.
+        Live mode: webhook cache first, then optional poll if SOLVENT_ALLOW_POLL=1.
         """
         if not self.live or link.get("simulated"):
             sim_suffix = uuid.uuid4().hex[:12]
             return {
                 "paid": True,
                 "stripe_ref": f"pi_sim_{sim_suffix}",
-                "checkout_session_id": f"cs_sim_{sim_suffix}",
-                "payment_link_id": link["id"],
+            "checkout_session_id": link.get("id", f"cs_sim_{sim_suffix}"),
+            "payment_link_id": link.get("payment_link_id") or (link["id"] if str(link.get("id", "")).startswith("plink_") else None),
                 "amount_cents": link["amount_cents"],
                 "simulated": True,
+                "job_id": job_id or link.get("job_id"),
                 "ts": time.time(),
             }
-        if self.webhook_secret and link["id"] in self._webhook_payments:
-            cached = self._webhook_payments[link["id"]]
-            if cached.get("paid"):
+        jid = job_id or link.get("job_id")
+        if jid:
+            cached = self.get_cached_payment(jid)
+            if cached and cached.get("paid"):
                 return cached
-        return self._poll_checkout_session(link["id"], link)
+        sid = link.get("id", "")
+        if sid.startswith("cs_") and os.environ.get("SOLVENT_ALLOW_POLL", "").strip() in ("1", "true", "yes"):
+            return self._poll_checkout_session_by_id(sid, link)
+        if sid.startswith("plink_"):
+            if self.webhook_secret and sid in self._webhook_payments:
+                cached = self._webhook_payments[sid]
+                if cached.get("paid"):
+                    return cached
+            if os.environ.get("SOLVENT_ALLOW_POLL", "").strip() in ("1", "true", "yes"):
+                return self._poll_checkout_session(sid, link)
+        return {
+            "paid": False,
+            "reason": "awaiting webhook confirmation",
+            "amount_cents": link["amount_cents"],
+            "ts": time.time(),
+        }
 
     # ---- SPEND (Issuing) --------------------------------------------
     def _issuing_enabled(self) -> bool:
@@ -339,17 +460,21 @@ class StripeClient:
         }
 
     # ---- REFUND -----------------------------------------------------
-    def refund_payment(self, payment_intent_id: str, amount_cents: int) -> dict:
+    def refund_payment(self, payment_intent_id: str, amount_cents: int, job_id: str | None = None) -> dict:
         """Refund a verified PaymentIntent (test mode or simulated)."""
         if self.live:
             if not payment_intent_id or not str(payment_intent_id).startswith("pi_"):
                 raise ValueError(
                     f"refund requires a PaymentIntent id (pi_...), got: {payment_intent_id!r}"
                 )
-            refund = stripe.Refund.create(
-                payment_intent=payment_intent_id,
-                amount=amount_cents,
-            )
+            kwargs = {
+                "payment_intent": payment_intent_id,
+                "amount": amount_cents,
+            }
+            if job_id:
+                refund = stripe.Refund.create(idempotency_key=f"refund-{job_id}", **kwargs)
+            else:
+                refund = stripe.Refund.create(**kwargs)
             return {
                 "id": refund.id,
                 "stripe_ref": payment_intent_id,

--- a/solvent/tools.py
+++ b/solvent/tools.py
@@ -1,0 +1,109 @@
+"""Allowlisted research tools for the bounded Nemotron agent loop."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import urllib.parse
+import urllib.request
+from dataclasses import dataclass, field
+
+MAX_TOOL_ROUNDS = 8
+MAX_TOOL_CALLS = 20
+
+ALLOWED_TOOLS = frozenset({"web_search", "market_data", "summarize"})
+
+
+@dataclass
+class ToolContext:
+    """Tracks tool invocations for COGS and guardrails."""
+
+    calls: list[dict] = field(default_factory=list)
+    web_search_calls: int = 0
+    market_data_calls: int = 0
+
+    def record(self, name: str, args: dict, result: str) -> None:
+        self.calls.append({"tool": name, "args": args, "result_len": len(result)})
+        if name == "web_search":
+            self.web_search_calls += 1
+        elif name == "market_data":
+            self.market_data_calls += 1
+
+    @property
+    def total_calls(self) -> int:
+        return len(self.calls)
+
+
+def _stub_web_search(query: str) -> str:
+    digest = hashlib.sha256(query.encode()).hexdigest()[:8]
+    return (
+        f"[offline web_search] Query: {query[:120]}\n"
+        f"- Finding A ({digest}): demand signals accelerating.\n"
+        f"- Finding B: competitive set consolidating.\n"
+        f"- Finding C: regulatory risk in two jurisdictions."
+    )
+
+
+def _live_web_search(query: str) -> str:
+    try:
+        url = "https://api.duckduckgo.com/?" + urllib.parse.urlencode({
+            "q": query[:200],
+            "format": "json",
+            "no_redirect": "1",
+        })
+        req = urllib.request.Request(url, headers={"User-Agent": "SOLVENT/1.0"})
+        with urllib.request.urlopen(req, timeout=8) as resp:
+            data = json.loads(resp.read())
+        abstract = data.get("AbstractText") or data.get("Heading") or ""
+        related = [t.get("Text", "") for t in (data.get("RelatedTopics") or [])[:3]]
+        snippets = "\n".join(f"- {s}" for s in related if s)
+        return f"{abstract}\n{snippets}".strip() or _stub_web_search(query)
+    except Exception:
+        return _stub_web_search(query)
+
+
+def _stub_market_data(symbol: str) -> str:
+    sym = symbol.upper()[:12]
+    seed = int(hashlib.md5(sym.encode()).hexdigest()[:6], 16)
+    price = 50 + (seed % 450)
+    return (
+        f"[market_data] {sym}: last ${price}.52, 30d range ${price-20}-${price+30}, "
+        f"vol +{(seed % 40)}% YoY (offline stub)."
+    )
+
+
+def web_search(query: str, *, live: bool = False) -> str:
+    if not query or not isinstance(query, str):
+        return "empty query"
+    return _live_web_search(query) if live else _stub_web_search(query)
+
+
+def market_data(symbol: str, *, live: bool = False) -> str:
+    if not symbol or not isinstance(symbol, str):
+        return "empty symbol"
+    return _stub_market_data(symbol)
+
+
+def summarize(text: str, nemotron_fn) -> str:
+    if not text:
+        return ""
+    system = "Summarize the following research notes in 3-5 bullet points."
+    result, _ = nemotron_fn(system, text[:4000])
+    return result
+
+
+def dispatch(name: str, args: dict, ctx: ToolContext, nemotron_fn, live_search: bool = False) -> str:
+    if name not in ALLOWED_TOOLS:
+        raise ValueError(f"tool {name!r} not allowlisted")
+    if ctx.total_calls >= MAX_TOOL_CALLS:
+        raise RuntimeError(f"max tool calls ({MAX_TOOL_CALLS}) exceeded")
+    if name == "web_search":
+        result = web_search(args.get("query", ""), live=live_search)
+    elif name == "market_data":
+        result = market_data(args.get("symbol", ""), live=live_search)
+    elif name == "summarize":
+        result = summarize(args.get("text", ""), nemotron_fn)
+    else:
+        raise ValueError(f"unknown tool: {name}")
+    ctx.record(name, args, result)
+    return result

--- a/solvent/treasury.py
+++ b/solvent/treasury.py
@@ -11,6 +11,7 @@ Storage is a SQLite database so it is thread-safe, concurrent, and survives rest
 
 from __future__ import annotations
 
+import json
 import sqlite3
 import time
 import uuid
@@ -110,6 +111,61 @@ class Treasury:
                         error_reason TEXT
                     )
                 """)
+                for col, ctype in (
+                    ("checkout_session_id", "TEXT"),
+                    ("checkout_url", "TEXT"),
+                    ("deliverable_url", "TEXT"),
+                    ("current_stage", "TEXT"),
+                    ("quote_json", "TEXT"),
+                    ("locked_until", "REAL"),
+                    ("job_payload_json", "TEXT"),
+                ):
+                    self._ensure_column(conn, "jobs", col, ctype)
+                conn.execute("""
+                    CREATE TABLE IF NOT EXISTS job_stages (
+                        id TEXT PRIMARY KEY,
+                        job_id TEXT NOT NULL,
+                        stage TEXT NOT NULL,
+                        idempotency_key TEXT NOT NULL UNIQUE,
+                        status TEXT NOT NULL,
+                        payload_json TEXT,
+                        result_json TEXT,
+                        ts REAL NOT NULL
+                    )
+                """)
+                conn.execute("""
+                    CREATE TABLE IF NOT EXISTS job_metrics (
+                        job_id TEXT PRIMARY KEY,
+                        est_cost_cents INTEGER,
+                        actual_cost_cents INTEGER,
+                        est_margin_pct REAL,
+                        actual_margin_pct REAL,
+                        margin_drift_cents INTEGER,
+                        fulfillment_seconds REAL,
+                        refunded INTEGER DEFAULT 0,
+                        tool_calls INTEGER DEFAULT 0,
+                        decline_reason TEXT,
+                        ts REAL NOT NULL
+                    )
+                """)
+                conn.execute("""
+                    CREATE TABLE IF NOT EXISTS stripe_checkout (
+                        job_id TEXT PRIMARY KEY,
+                        session_id TEXT,
+                        checkout_url TEXT,
+                        status TEXT,
+                        ts REAL NOT NULL
+                    )
+                """)
+                conn.execute("""
+                    CREATE TABLE IF NOT EXISTS events (
+                        id TEXT PRIMARY KEY,
+                        job_id TEXT,
+                        stage TEXT,
+                        payload_json TEXT,
+                        ts REAL NOT NULL
+                    )
+                """)
 
     @contextmanager
     def lock(self):
@@ -182,6 +238,10 @@ class Treasury:
                 with conn:
                     conn.execute("DELETE FROM ledger")
                     conn.execute("DELETE FROM jobs")
+                    conn.execute("DELETE FROM job_stages")
+                    conn.execute("DELETE FROM job_metrics")
+                    conn.execute("DELETE FROM stripe_checkout")
+                    conn.execute("DELETE FROM events")
 
     # ---- writes ------------------------------------------------------
     def record(self, kind: EntryKind, amount_cents: int, memo: str, **kw) -> LedgerEntry:
@@ -285,6 +345,12 @@ class Treasury:
             }
 
     # ---- job queue ----------------------------------------------------
+    _JOB_COLS = (
+        "topic", "budget_cents", "customer_email", "est_tokens", "market_data_calls",
+        "web_search_calls", "error_reason", "checkout_session_id", "checkout_url",
+        "deliverable_url", "current_stage", "quote_json", "locked_until", "job_payload_json",
+    )
+
     def upsert_job(self, job_id: str, status: str, **kwargs) -> None:
         """Upsert a job's status and other fields in the persistent job queue table."""
         with self.lock():
@@ -295,18 +361,24 @@ class Treasury:
                     if existing:
                         fields = ["status = ?", "updated_at = ?"]
                         params = [status, ts]
-                        for col in ("topic", "budget_cents", "customer_email", "est_tokens", "market_data_calls", "web_search_calls", "error_reason"):
+                        for col in self._JOB_COLS:
                             if col in kwargs:
+                                val = kwargs[col]
+                                if col == "job_payload_json" and isinstance(val, dict):
+                                    val = json.dumps(val)
                                 fields.append(f"{col} = ?")
-                                params.append(kwargs[col])
+                                params.append(val)
                         params.append(job_id)
                         conn.execute(f"UPDATE jobs SET {', '.join(fields)} WHERE id = ?", params)
                     else:
                         cols = ["id", "status", "created_at", "updated_at"]
                         vals = [job_id, status, ts, ts]
-                        for col in ("topic", "budget_cents", "customer_email", "est_tokens", "market_data_calls", "web_search_calls", "error_reason"):
+                        for col in self._JOB_COLS:
                             cols.append(col)
-                            vals.append(kwargs.get(col))
+                            val = kwargs.get(col)
+                            if col == "job_payload_json" and isinstance(val, dict):
+                                val = json.dumps(val)
+                            vals.append(val)
                         placeholders = ", ".join(["?"] * len(cols))
                         conn.execute(f"INSERT INTO jobs ({', '.join(cols)}) VALUES ({placeholders})", vals)
 
@@ -321,6 +393,202 @@ class Treasury:
             with self._conn() as conn:
                 rows = conn.execute("SELECT * FROM jobs ORDER BY created_at ASC").fetchall()
                 return [dict(row) for row in rows]
+
+    def list_jobs_by_status(self, statuses: list[str]) -> list[dict]:
+        if not statuses:
+            return []
+        placeholders = ", ".join("?" * len(statuses))
+        with self.lock():
+            with self._conn() as conn:
+                rows = conn.execute(
+                    f"SELECT * FROM jobs WHERE status IN ({placeholders}) ORDER BY created_at ASC",
+                    statuses,
+                ).fetchall()
+                return [dict(row) for row in rows]
+
+    def claim_job(self, job_id: str, lease_seconds: float = 60.0) -> bool:
+        """Acquire a short lease on a job for worker processing."""
+        now = time.time()
+        until = now + lease_seconds
+        with self.lock():
+            with self._conn() as conn:
+                with conn:
+                    row = conn.execute(
+                        "SELECT locked_until FROM jobs WHERE id = ?", (job_id,)
+                    ).fetchone()
+                    if not row:
+                        return False
+                    locked = row["locked_until"]
+                    if locked and locked > now:
+                        return False
+                    conn.execute(
+                        "UPDATE jobs SET locked_until = ?, updated_at = ? WHERE id = ?",
+                        (until, now, job_id),
+                    )
+                    return True
+
+    def release_job(self, job_id: str) -> None:
+        with self.lock():
+            with self._conn() as conn:
+                with conn:
+                    conn.execute(
+                        "UPDATE jobs SET locked_until = NULL, updated_at = ? WHERE id = ?",
+                        (time.time(), job_id),
+                    )
+
+    def get_stage(self, idempotency_key: str) -> Optional[dict]:
+        with self.lock():
+            with self._conn() as conn:
+                row = conn.execute(
+                    "SELECT * FROM job_stages WHERE idempotency_key = ?",
+                    (idempotency_key,),
+                ).fetchone()
+                return dict(row) if row else None
+
+    def complete_stage(
+        self,
+        job_id: str,
+        stage: str,
+        idempotency_key: str,
+        result: dict | None = None,
+        payload: dict | None = None,
+    ) -> dict:
+        with self.lock():
+            existing = self.get_stage(idempotency_key)
+            if existing and existing["status"] == "completed":
+                return json.loads(existing["result_json"] or "{}")
+            stage_id = "st_" + uuid.uuid4().hex[:12]
+            ts = time.time()
+            with self._conn() as conn:
+                with conn:
+                    conn.execute("""
+                        INSERT OR REPLACE INTO job_stages
+                        (id, job_id, stage, idempotency_key, status, payload_json, result_json, ts)
+                        VALUES (?, ?, ?, ?, 'completed', ?, ?, ?)
+                    """, (
+                        stage_id,
+                        job_id,
+                        stage,
+                        idempotency_key,
+                        json.dumps(payload or {}),
+                        json.dumps(result or {}),
+                        ts,
+                    ))
+            return result or {}
+
+    def record_event(self, job_id: str, stage: str, payload: dict) -> None:
+        with self.lock():
+            with self._conn() as conn:
+                with conn:
+                    conn.execute(
+                        "INSERT INTO events (id, job_id, stage, payload_json, ts) VALUES (?, ?, ?, ?, ?)",
+                        ("ev_" + uuid.uuid4().hex[:12], job_id, stage, json.dumps(payload), time.time()),
+                    )
+
+    def list_events(self, job_id: str | None = None, limit: int = 500) -> list[dict]:
+        with self.lock():
+            with self._conn() as conn:
+                if job_id:
+                    rows = conn.execute(
+                        "SELECT * FROM events WHERE job_id = ? ORDER BY ts DESC LIMIT ?",
+                        (job_id, limit),
+                    ).fetchall()
+                else:
+                    rows = conn.execute(
+                        "SELECT * FROM events ORDER BY ts DESC LIMIT ?", (limit,)
+                    ).fetchall()
+                return [dict(r) for r in rows]
+
+    def upsert_metrics(self, job_id: str, **kwargs) -> None:
+        with self.lock():
+            with self._conn() as conn:
+                with conn:
+                    existing = conn.execute(
+                        "SELECT job_id FROM job_metrics WHERE job_id = ?", (job_id,)
+                    ).fetchone()
+                    ts = time.time()
+                    if existing:
+                        fields = ["ts = ?"]
+                        params: list = [ts]
+                        for col in (
+                            "est_cost_cents", "actual_cost_cents", "est_margin_pct",
+                            "actual_margin_pct", "margin_drift_cents", "fulfillment_seconds",
+                            "refunded", "tool_calls", "decline_reason",
+                        ):
+                            if col in kwargs:
+                                fields.append(f"{col} = ?")
+                                params.append(kwargs[col])
+                        params.append(job_id)
+                        conn.execute(
+                            f"UPDATE job_metrics SET {', '.join(fields)} WHERE job_id = ?",
+                            params,
+                        )
+                    else:
+                        cols = ["job_id", "ts"]
+                        vals: list = [job_id, ts]
+                        for col in (
+                            "est_cost_cents", "actual_cost_cents", "est_margin_pct",
+                            "actual_margin_pct", "margin_drift_cents", "fulfillment_seconds",
+                            "refunded", "tool_calls", "decline_reason",
+                        ):
+                            if col in kwargs:
+                                cols.append(col)
+                                vals.append(kwargs[col])
+                        placeholders = ", ".join(["?"] * len(cols))
+                        conn.execute(
+                            f"INSERT INTO job_metrics ({', '.join(cols)}) VALUES ({placeholders})",
+                            vals,
+                        )
+
+    def get_metrics(self, job_id: str) -> Optional[dict]:
+        with self.lock():
+            with self._conn() as conn:
+                row = conn.execute(
+                    "SELECT * FROM job_metrics WHERE job_id = ?", (job_id,)
+                ).fetchone()
+                return dict(row) if row else None
+
+    def list_metrics(self) -> list[dict]:
+        with self.lock():
+            with self._conn() as conn:
+                rows = conn.execute("SELECT * FROM job_metrics ORDER BY ts ASC").fetchall()
+                return [dict(r) for r in rows]
+
+    def upsert_checkout(self, job_id: str, session_id: str, checkout_url: str, status: str) -> None:
+        with self.lock():
+            with self._conn() as conn:
+                with conn:
+                    conn.execute("""
+                        INSERT OR REPLACE INTO stripe_checkout
+                        (job_id, session_id, checkout_url, status, ts)
+                        VALUES (?, ?, ?, ?, ?)
+                    """, (job_id, session_id, checkout_url, status, time.time()))
+
+    def get_checkout(self, job_id: str) -> Optional[dict]:
+        with self.lock():
+            with self._conn() as conn:
+                row = conn.execute(
+                    "SELECT * FROM stripe_checkout WHERE job_id = ?", (job_id,)
+                ).fetchone()
+                return dict(row) if row else None
+
+    def job_has_revenue(self, job_id: str) -> bool:
+        with self.lock():
+            with self._conn() as conn:
+                row = conn.execute(
+                    "SELECT COUNT(*) as c FROM ledger WHERE job_id = ? AND kind = 'revenue'",
+                    (job_id,),
+                ).fetchone()
+                return (row["c"] or 0) > 0
+
+    def stage_completed(self, job_id: str, stage: str) -> bool:
+        with self.lock():
+            with self._conn() as conn:
+                row = conn.execute(
+                    "SELECT COUNT(*) as c FROM job_stages WHERE job_id = ? AND stage = ? AND status = 'completed'",
+                    (job_id, stage),
+                ).fetchone()
+                return (row["c"] or 0) > 0
 
 
 def fmt(cents: int) -> str:

--- a/solvent/worker.py
+++ b/solvent/worker.py
@@ -1,0 +1,56 @@
+"""Background worker for async SOLVENT job processing."""
+
+from __future__ import annotations
+
+import os
+import time
+
+from .agent import Solvent
+from .queue import list_claimable, resume_incomplete_jobs
+
+
+def run_worker(
+    *,
+    once: bool = False,
+    poll_interval: float = 2.0,
+    seed_cents: int = 10_000,
+    fresh: bool = False,
+) -> None:
+    agent = Solvent(seed_cents=seed_cents, fresh=fresh, sync_payment=False)
+    resumed = resume_incomplete_jobs(agent.t)
+    for job_id in resumed:
+        agent.advance_job(job_id)
+
+    while True:
+        jobs = list_claimable(agent.t)
+        for job in jobs:
+            job_id = job["id"]
+            if not agent.t.claim_job(job_id):
+                continue
+            try:
+                agent.advance_job(job_id)
+            finally:
+                agent.t.release_job(job_id)
+        if once:
+            break
+        time.sleep(poll_interval)
+
+
+def main():
+    import argparse
+    parser = argparse.ArgumentParser(description="SOLVENT async job worker")
+    parser.add_argument("--once", action="store_true", help="process one pass then exit")
+    parser.add_argument("--poll-interval", type=float, default=2.0)
+    parser.add_argument("--seed", type=float, default=100.0)
+    parser.add_argument("--keep-balance", action="store_true")
+    args = parser.parse_args()
+    run_worker(
+        once=args.once,
+        poll_interval=args.poll_interval,
+        seed_cents=int(args.seed * 100),
+        fresh=not args.keep_balance,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_delivery.py
+++ b/tests/test_delivery.py
@@ -1,0 +1,36 @@
+"""Tests for delivery tokens and outbox email."""
+
+import tempfile
+import unittest
+from pathlib import Path
+
+from solvent.delivery import (
+    make_delivery_token,
+    verify_delivery_token,
+    send_brief_email,
+    hosted_brief_url,
+)
+
+
+class TestDelivery(unittest.TestCase):
+    def test_token_roundtrip(self):
+        token = make_delivery_token("J1")
+        self.assertTrue(verify_delivery_token("J1", token))
+        self.assertFalse(verify_delivery_token("J2", token))
+
+    def test_hosted_url(self):
+        url = hosted_brief_url("http://localhost:8787", "J1")
+        self.assertIn("/briefs/J1", url)
+        self.assertIn("token=", url)
+
+    def test_outbox_email_without_smtp(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            brief = Path(tmp) / "J1.md"
+            brief.write_text("# Test brief")
+            result = send_brief_email("user@test.com", "J1", brief, "http://localhost/briefs/J1")
+            self.assertTrue(result["simulated"])
+            self.assertTrue(Path(result["path"]).is_file())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_improver.py
+++ b/tests/test_improver.py
@@ -1,0 +1,28 @@
+"""Tests for auto-improvement tuner."""
+
+import unittest
+
+from solvent.improver import analyze_metrics, propose_changes
+from solvent.treasury import Treasury
+
+
+class TestImprover(unittest.TestCase):
+    def test_not_ready_with_few_jobs(self):
+        t = Treasury()
+        t.reset()
+        analysis = analyze_metrics(t)
+        self.assertFalse(analysis["ready"])
+
+    def test_proposes_pricing_when_margin_negative(self):
+        proposals = propose_changes({
+            "ready": True,
+            "avg_margin_error": -8,
+            "refund_rate": 0.05,
+            "avg_fulfillment_seconds": 60,
+        })
+        kinds = [p["type"] for p in proposals]
+        self.assertIn("pricing", kinds)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_reconcile.py
+++ b/tests/test_reconcile.py
@@ -1,0 +1,21 @@
+"""Tests for Stripe reconciliation."""
+
+import unittest
+
+from solvent.reconcile import reconcile
+from solvent.treasury import Treasury
+
+
+class TestReconcile(unittest.TestCase):
+    def test_ledger_only_mode(self):
+        t = Treasury()
+        t.reset()
+        t.seed(10_000)
+        t.earn(5000, "test", job_id="J1", stripe_ref="pi_sim_abc")
+        report = reconcile(t)
+        self.assertEqual(report["mode"], "ledger_only")
+        self.assertIn("pi_sim_abc", report["unmatched_ledger"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -278,6 +278,13 @@ class TestValidateCatalogSchema:
         clean = validate_catalog_schema(raw)
         assert clean["product_id"] == "prod_abc123"
         assert clean["price_ids"]["4900"] == "price_xyz789"
+        assert clean["prices"]["4900"] == "price_xyz789"
+
+    def test_prices_key_accepted(self):
+        raw = {"prices": {"4900": "price_abc123"}, "product_id": "prod_abc123"}
+        clean = validate_catalog_schema(raw)
+        assert clean["prices"]["4900"] == "price_abc123"
+        assert clean["price_ids"]["4900"] == "price_abc123"
 
     def test_unknown_keys_stripped(self):
         raw = {

--- a/tests/test_stages.py
+++ b/tests/test_stages.py
@@ -1,0 +1,61 @@
+"""Tests for idempotent job stages."""
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+from solvent.agent import Solvent
+from solvent.treasury import Treasury
+
+
+class TestStagesIdempotency(unittest.TestCase):
+    def test_double_paid_stage_does_not_double_earn(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            db = Path(tmp) / "t.db"
+            agent = Solvent(seed_cents=10_000, fresh=True)
+            agent.t.path = db
+            agent.t.lock_path = db.with_suffix(".lock")
+            agent.t._init_db()
+
+            job = {
+                "id": "J-idem",
+                "topic": "Idempotency test",
+                "budget_cents": 5000,
+                "est_tokens": 1000,
+                "market_data_calls": 1,
+                "web_search_calls": 1,
+            }
+            link = {"id": "cs_sim", "url": "http://x", "amount_cents": 5000, "simulated": True, "job_id": "J-idem"}
+            payment = {
+                "paid": True,
+                "stripe_ref": "pi_idem",
+                "checkout_session_id": "cs_idem",
+                "amount_cents": 5000,
+            }
+            fulfill = {
+                "deliverable_path": str(Path(tmp) / "J-idem.md"),
+                "tokens": 50,
+                "resources_used": [],
+                "actual_cost_cents": 0,
+                "fulfillment_seconds": 0.5,
+                "tool_ctx": type("C", (), {"total_calls": 0, "market_data_calls": 0, "web_search_calls": 0})(),
+                "usage": {"total_tokens": 50},
+            }
+            Path(fulfill["deliverable_path"]).write_text("# brief")
+
+            with mock.patch.object(agent.stripe, "create_checkout_session", return_value=link):
+                with mock.patch.object(agent.stripe, "confirm_payment", return_value=payment):
+                    with mock.patch("solvent.service.fulfill", return_value=fulfill):
+                        with mock.patch("solvent.delivery.send_brief_email", return_value={"simulated": True}):
+                            agent.handle_job(job)
+                            rev1 = len([e for e in agent.t.entries if e.kind == "revenue" and e.job_id == "J-idem"])
+                            agent._runner._stage_paid(job, link, agent._runner._stage_quote(job).get("_quote") or mock.Mock(price_cents=5000, est_cost_cents=100, margin_cents=4900, margin_pct=90))
+                            rev2 = len([e for e in agent.t.entries if e.kind == "revenue" and e.job_id == "J-idem"])
+            self.assertEqual(rev1, 1)
+            self.assertEqual(rev2, 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_stripe_client.py
+++ b/tests/test_stripe_client.py
@@ -36,8 +36,11 @@ class TestStripeClientSimulate(unittest.TestCase):
         payment = client.confirm_payment(link)
         self.assertTrue(payment["paid"])
         self.assertTrue(payment["stripe_ref"].startswith("pi_sim_"))
-        self.assertTrue(payment["checkout_session_id"].startswith("cs_sim_"))
-        self.assertEqual(payment["payment_link_id"], link["id"])
+        self.assertTrue(
+            payment["checkout_session_id"].startswith("cs_sim_")
+            or payment["checkout_session_id"].startswith("plink_sim_")
+        )
+        self.assertIn(payment.get("payment_link_id"), (link["id"], None))
 
     def test_simulate_refund(self):
         client = StripeClient()
@@ -127,9 +130,10 @@ class TestStripeClientLive(unittest.TestCase):
             mock.Mock(data=[paid]),
         ]
 
-        client = StripeClient()
-        link = {"id": "plink_x", "amount_cents": 4900, "simulated": False}
-        payment = client.confirm_payment(link)
+        with mock.patch.dict(os.environ, {"SOLVENT_ALLOW_POLL": "1"}, clear=False):
+            client = StripeClient()
+            link = {"id": "plink_x", "amount_cents": 4900, "simulated": False}
+            payment = client.confirm_payment(link)
 
         self.assertTrue(payment["paid"])
         self.assertEqual(payment["stripe_ref"], "pi_paid123")
@@ -140,12 +144,20 @@ class TestStripeClientLive(unittest.TestCase):
         unpaid = mock.Mock(payment_status="unpaid")
         self._mock_stripe.checkout.Session.list.return_value = mock.Mock(data=[unpaid])
 
-        client = StripeClient()
-        link = {"id": "plink_x", "amount_cents": 4900, "simulated": False}
-        payment = client.confirm_payment(link)
+        with mock.patch.dict(os.environ, {"SOLVENT_ALLOW_POLL": "1"}, clear=False):
+            client = StripeClient()
+            link = {"id": "plink_x", "amount_cents": 4900, "simulated": False}
+            payment = client.confirm_payment(link)
 
         self.assertFalse(payment["paid"])
         self.assertIn("not received", payment["reason"])
+
+    def test_confirm_payment_awaits_webhook_by_default(self):
+        client = StripeClient()
+        link = {"id": "cs_test123", "amount_cents": 4900, "simulated": False, "job_id": "J1"}
+        payment = client.confirm_payment(link, job_id="J1")
+        self.assertFalse(payment["paid"])
+        self.assertIn("webhook", payment["reason"])
 
     def test_refund_requires_payment_intent(self):
         client = StripeClient()
@@ -176,6 +188,8 @@ class TestStripeClientLive(unittest.TestCase):
             "payment_intent": "pi_wh",
             "payment_link": "plink_wh",
             "amount_total": 7500,
+            "metadata": {"job_id": "J-wh"},
+            "client_reference_id": "J-wh",
         }
         self._mock_stripe.Webhook.construct_event.return_value = {
             "id": "evt_test_webhook_cache",
@@ -195,12 +209,32 @@ class TestStripeClientLive(unittest.TestCase):
             result = client.process_webhook(payload, valid_sig)
             self.assertTrue(result["paid"])
             self.assertEqual(result["stripe_ref"], "pi_wh")
+            self.assertEqual(result["job_id"], "J-wh")
 
-            link = {"id": "plink_wh", "amount_cents": 7500, "simulated": False}
-            payment = client.confirm_payment(link)
+            link = {"id": "plink_wh", "amount_cents": 7500, "simulated": False, "job_id": "J-wh"}
+            payment = client.confirm_payment(link, job_id="J-wh")
             self.assertTrue(payment["paid"])
             self.assertEqual(payment["stripe_ref"], "pi_wh")
             self._mock_stripe.checkout.Session.list.assert_not_called()
+
+    def test_create_checkout_session_live(self):
+        self._mock_stripe.checkout.Session.create.return_value = mock.Mock(
+            id="cs_new", url="https://checkout.stripe.test/cs_new"
+        )
+        client = StripeClient()
+        session = client.create_checkout_session(
+            job_id="J1",
+            amount_cents=4900,
+            customer_email="a@b.com",
+            name="Brief",
+            success_url="http://localhost/success",
+            cancel_url="http://localhost/cancel",
+        )
+        self.assertEqual(session["id"], "cs_new")
+        self._mock_stripe.checkout.Session.create.assert_called_once()
+        call_kwargs = self._mock_stripe.checkout.Session.create.call_args.kwargs
+        self.assertEqual(call_kwargs["client_reference_id"], "J1")
+        self.assertEqual(call_kwargs["idempotency_key"], "checkout-J1")
 
 
     def test_issuing_card_when_available(self):
@@ -239,14 +273,15 @@ class TestAgentPaymentFlow(unittest.TestCase):
             agent.t._init_db()
 
             link = {
-                "id": "plink_test",
-                "url": "https://pay.test/link",
+                "id": "cs_test",
+                "url": "https://pay.test/checkout",
                 "amount_cents": 4900,
                 "simulated": True,
+                "job_id": "J-test",
             }
             pending = {"paid": False, "reason": "payment not received within 120s"}
 
-            with mock.patch.object(agent.stripe, "create_payment_link", return_value=link):
+            with mock.patch.object(agent.stripe, "create_checkout_session", return_value=link):
                 with mock.patch.object(agent.stripe, "confirm_payment", return_value=pending):
                     with mock.patch("solvent.service.fulfill") as mock_fulfill:
                         result = agent.handle_job(
@@ -273,42 +308,47 @@ class TestAgentPaymentFlow(unittest.TestCase):
             agent.t._init_db()
 
             link = {
-                "id": "plink_test",
-                "url": "https://pay.test/link",
+                "id": "cs_test",
+                "url": "https://pay.test/checkout",
                 "amount_cents": 4900,
                 "simulated": True,
+                "job_id": "J-test",
             }
             payment = {
                 "paid": True,
                 "stripe_ref": "pi_test123",
                 "checkout_session_id": "cs_test123",
-                "payment_link_id": "plink_test",
+                "payment_link_id": None,
                 "amount_cents": 4900,
             }
 
-            with mock.patch.object(agent.stripe, "create_payment_link", return_value=link):
+            with mock.patch.object(agent.stripe, "create_checkout_session", return_value=link):
                 with mock.patch.object(agent.stripe, "confirm_payment", return_value=payment):
                     with mock.patch("solvent.service.fulfill") as mock_fulfill:
                         mock_fulfill.return_value = {
-                            "deliverable_path": "/tmp/x.md",
+                            "deliverable_path": str(Path(tmp) / "x.md"),
                             "tokens": 100,
                             "resources_used": [],
+                            "actual_cost_cents": 0,
+                            "fulfillment_seconds": 1.0,
+                            "tool_ctx": type("C", (), {"total_calls": 0, "market_data_calls": 0, "web_search_calls": 0})(),
+                            "usage": {"total_tokens": 100},
                         }
-                        agent.handle_job(
-                            {
-                                "id": "J-test",
-                                "topic": "Test topic",
-                                "budget_cents": 5000,
-                                "est_tokens": 1000,
-                                "market_data_calls": 1,
-                                "web_search_calls": 1,
-                            }
-                        )
+                        with mock.patch("solvent.delivery.send_brief_email", return_value={"simulated": True}):
+                            agent.handle_job(
+                                {
+                                    "id": "J-test",
+                                    "topic": "Test topic",
+                                    "budget_cents": 5000,
+                                    "est_tokens": 1000,
+                                    "market_data_calls": 1,
+                                    "web_search_calls": 1,
+                                }
+                            )
             rev = [e for e in agent.t.entries if e.kind == "revenue" and e.job_id == "J-test"]
             self.assertEqual(len(rev), 1)
             self.assertEqual(rev[0].stripe_ref, "pi_test123")
             self.assertEqual(rev[0].stripe_session_id, "cs_test123")
-            self.assertEqual(rev[0].stripe_link_id, "plink_test")
 
 
 if __name__ == "__main__":

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -1,0 +1,32 @@
+"""Tests for bounded research tools."""
+
+import unittest
+
+from solvent.tools import ToolContext, dispatch, MAX_TOOL_CALLS, ALLOWED_TOOLS
+
+
+class TestTools(unittest.TestCase):
+    def test_allowlist(self):
+        ctx = ToolContext()
+        result = dispatch("web_search", {"query": "AI chips"}, ctx, lambda s, u: ("ok", {}))
+        self.assertIn("offline web_search", result)
+        self.assertEqual(ctx.web_search_calls, 1)
+
+    def test_rejects_unknown_tool(self):
+        ctx = ToolContext()
+        with self.assertRaises(ValueError):
+            dispatch("hack_the_planet", {}, ctx, lambda s, u: ("", {}))
+
+    def test_max_calls(self):
+        ctx = ToolContext()
+        for i in range(MAX_TOOL_CALLS):
+            dispatch("web_search", {"query": f"q{i}"}, ctx, lambda s, u: ("", {}))
+        with self.assertRaises(RuntimeError):
+            dispatch("web_search", {"query": "one more"}, ctx, lambda s, u: ("", {}))
+
+    def test_allowed_set(self):
+        self.assertIn("market_data", ALLOWED_TOOLS)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -1,0 +1,28 @@
+"""Tests for worker resume logic."""
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from solvent.queue import resume_incomplete_jobs
+from solvent.treasury import Treasury
+
+
+class TestWorkerResume(unittest.TestCase):
+    def test_resume_paid_unfulfilled(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            db = Path(tmp) / "w.db"
+            t = Treasury(path=db)
+            t.reset()
+            t.seed(10_000)
+            t.upsert_job("J-stuck", "in_progress", topic="t", budget_cents=5000, job_payload_json={"id": "J-stuck"})
+            t.earn(5000, "paid", job_id="J-stuck", stripe_ref="pi_x")
+            resumed = resume_incomplete_jobs(t)
+            self.assertIn("J-stuck", resumed)
+            job = t.get_job("J-stuck")
+            self.assertEqual(job["status"], "paid_pending_fulfill")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- **Webhook-first Stripe**: Checkout Sessions with `metadata.job_id`, idempotency keys, and `POST /webhooks/stripe` (polling opt-in via `SOLVENT_ALLOW_POLL`)
- **Async workers**: SQLite-backed queue, `python -m solvent worker`, resume incomplete paid jobs
- **Idempotent stages**: `job_stages` table with keys for quote/paid/fulfill/spend/refund/deliver
- **Real COGS**: Actual Nemotron token usage + tool call counts → `job_metrics` with margin drift
- **Delivery**: Signed hosted briefs (`/briefs/{id}`) + SMTP or `data/outbox/` fallback
- **Bounded tool agent**: Allowlisted `web_search`, `market_data`, `summarize` in Nemotron research loop
- **Auto-improvement**: `python -m solvent tune` proposes/applies pricing overrides from metrics
- **Observability**: JSON logs (`data/solvent.log`), dashboard ops panel, `python -m solvent reconcile`
- **Offline demo preserved**: `python3 run_demo.py --no-onboard` still runs with zero deps

## Test plan

- [x] `python -m unittest discover -s tests` (50 tests pass)
- [x] `python3 run_demo.py --no-onboard` offline batch demo completes with profit
- [ ] `pip install -r requirements-serve.txt && python -m solvent serve` smoke test
- [ ] Stripe test webhook → worker advances job to fulfilled


Made with [Cursor](https://cursor.com)