### PR TITLE
Harden hosted brief delivery tokens

### DIFF
--- a/docs/PRODUCTION.md
+++ b/docs/PRODUCTION.md
@@ -15,7 +15,7 @@ pip install -r requirements.txt
 pip install -r requirements-serve.txt
 
 export SOLVENT_BASE_URL=http://127.0.0.1:8787
-export SOLVENT_DELIVERY_SECRET=change-me-in-production
+export SOLVENT_DELIVERY_SECRET="$(python3 -c 'import secrets; print(secrets.token_urlsafe(48))')"
 
 # Terminal 1 — API + webhooks + hosted briefs
 python3 -m solvent serve --port 8787
@@ -82,7 +82,7 @@ python3 -m solvent tune --apply
 | `STRIPE_API_KEY` | Test/restricted Stripe key |
 | `STRIPE_WEBHOOK_SECRET` | Webhook signature verification |
 | `SOLVENT_BASE_URL` | Checkout success URLs + hosted briefs |
-| `SOLVENT_DELIVERY_SECRET` | HMAC token for `/briefs/{id}` |
+| `SOLVENT_DELIVERY_SECRET` | Required high-entropy HMAC secret for `/briefs/{id}`; must be at least 32 bytes and not a placeholder |
 | `SOLVENT_ASYNC` | Non-blocking payment (worker resumes jobs) |
 | `SOLVENT_ALLOW_POLL` | Legacy payment polling |
 | `SOLVENT_LOG_JSON` | JSON lines to stderr + `data/solvent.log` |

--- a/solvent/delivery.py
+++ b/solvent/delivery.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import hashlib
 import hmac
 import os
+import re
 import smtplib
 import time
 from email.mime.multipart import MIMEMultipart
@@ -12,13 +13,28 @@ from email.mime.text import MIMEText
 from pathlib import Path
 
 OUTBOX_DIR = Path(__file__).resolve().parent.parent / "data" / "outbox"
+MIN_DELIVERY_SECRET_BYTES = 32
+INSECURE_DELIVERY_SECRETS = {"solvent-dev-secret-change-me", "change-me-in-production"}
+SAFE_JOB_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$")
 
 
 def _delivery_secret() -> str:
-    return os.environ.get("SOLVENT_DELIVERY_SECRET", "solvent-dev-secret-change-me")
+    secret = os.environ.get("SOLVENT_DELIVERY_SECRET", "").strip()
+    if secret in INSECURE_DELIVERY_SECRETS or len(secret.encode()) < MIN_DELIVERY_SECRET_BYTES:
+        raise RuntimeError(
+            "SOLVENT_DELIVERY_SECRET must be configured to a high-entropy "
+            "secret of at least 32 bytes before hosted brief delivery is used"
+        )
+    return secret
+
+
+def is_safe_job_id(job_id: str) -> bool:
+    return bool(SAFE_JOB_ID_RE.fullmatch(job_id))
 
 
 def make_delivery_token(job_id: str, ts: float | None = None) -> str:
+    if not is_safe_job_id(job_id):
+        raise ValueError("invalid job_id")
     ts = ts or time.time()
     payload = f"{job_id}:{int(ts)}"
     sig = hmac.new(_delivery_secret().encode(), payload.encode(), hashlib.sha256).hexdigest()
@@ -26,7 +42,7 @@ def make_delivery_token(job_id: str, ts: float | None = None) -> str:
 
 
 def verify_delivery_token(job_id: str, token: str, max_age_seconds: int = 7 * 86400) -> bool:
-    if not token or "." not in token:
+    if not is_safe_job_id(job_id) or not token or "." not in token:
         return False
     ts_str, sig = token.split(".", 1)
     try:
@@ -36,7 +52,10 @@ def verify_delivery_token(job_id: str, token: str, max_age_seconds: int = 7 * 86
     if abs(time.time() - ts) > max_age_seconds:
         return False
     payload = f"{job_id}:{ts}"
-    expected = hmac.new(_delivery_secret().encode(), payload.encode(), hashlib.sha256).hexdigest()
+    try:
+        expected = hmac.new(_delivery_secret().encode(), payload.encode(), hashlib.sha256).hexdigest()
+    except RuntimeError:
+        return False
     return hmac.compare_digest(expected, sig)
 
 

--- a/solvent/server.py
+++ b/solvent/server.py
@@ -7,7 +7,7 @@ import os
 from pathlib import Path
 
 from .agent import Solvent
-from .delivery import verify_delivery_token, markdown_to_html
+from .delivery import verify_delivery_token, markdown_to_html, is_safe_job_id
 from .stripe_client import StripeClient
 
 
@@ -61,14 +61,16 @@ def create_app(seed_cents: int = 10_000, fresh: bool = False) -> object:
 
     @app.get("/briefs/{job_id}")
     def get_brief(job_id: str, token: str = ""):
+        if not is_safe_job_id(job_id):
+            raise HTTPException(404, "brief not found")
         if not verify_delivery_token(job_id, token):
             raise HTTPException(403, "invalid or expired delivery token")
-        path = Path(__file__).resolve().parent.parent / "data" / "reports" / f"{job_id}.md"
-        if not path.is_file():
-            for p in (Path(__file__).resolve().parent.parent / "data" / "reports").glob("*.md"):
-                if job_id in p.stem:
-                    path = p
-                    break
+        reports_dir = Path(__file__).resolve().parent.parent / "data" / "reports"
+        path = (reports_dir / f"{job_id}.md").resolve()
+        try:
+            path.relative_to(reports_dir.resolve())
+        except ValueError:
+            raise HTTPException(404, "brief not found")
         if not path.is_file():
             raise HTTPException(404, "brief not found")
         return HTMLResponse(markdown_to_html(path.read_text(encoding="utf-8")))

--- a/tests/test_delivery.py
+++ b/tests/test_delivery.py
@@ -2,6 +2,7 @@
 
 import tempfile
 import unittest
+from unittest import mock
 from pathlib import Path
 
 from solvent.delivery import (
@@ -9,17 +10,40 @@ from solvent.delivery import (
     verify_delivery_token,
     send_brief_email,
     hosted_brief_url,
+    is_safe_job_id,
 )
 
 
 class TestDelivery(unittest.TestCase):
     def test_token_roundtrip(self):
-        token = make_delivery_token("J1")
-        self.assertTrue(verify_delivery_token("J1", token))
-        self.assertFalse(verify_delivery_token("J2", token))
+        with mock.patch.dict("os.environ", {"SOLVENT_DELIVERY_SECRET": "x" * 32}):
+            token = make_delivery_token("J1")
+            self.assertTrue(verify_delivery_token("J1", token))
+            self.assertFalse(verify_delivery_token("J2", token))
+
+    def test_unconfigured_or_insecure_secret_fails_closed(self):
+        with mock.patch.dict("os.environ", {}, clear=True):
+            self.assertFalse(verify_delivery_token("J1", "1.bad"))
+            with self.assertRaises(RuntimeError):
+                make_delivery_token("J1", ts=1)
+
+        for secret in ("short", "solvent-dev-secret-change-me", "change-me-in-production"):
+            with self.subTest(secret=secret):
+                with mock.patch.dict("os.environ", {"SOLVENT_DELIVERY_SECRET": secret}):
+                    self.assertFalse(verify_delivery_token("J1", "1.bad"))
+                    with self.assertRaises(RuntimeError):
+                        make_delivery_token("J1", ts=1)
+
+    def test_job_id_must_be_safe_for_hosted_delivery(self):
+        self.assertTrue(is_safe_job_id("J1.ok-123"))
+        for job_id in ("", "../J1", "/J1", "J1/other", "J" * 129):
+            with self.subTest(job_id=job_id):
+                self.assertFalse(is_safe_job_id(job_id))
+                self.assertFalse(verify_delivery_token(job_id, "1.bad"))
 
     def test_hosted_url(self):
-        url = hosted_brief_url("http://localhost:8787", "J1")
+        with mock.patch.dict("os.environ", {"SOLVENT_DELIVERY_SECRET": "x" * 32}):
+            url = hosted_brief_url("http://localhost:8787", "J1")
         self.assertIn("/briefs/J1", url)
         self.assertIn("token=", url)
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,0 +1,43 @@
+"""Tests for hosted brief serving."""
+
+import os
+import unittest
+from pathlib import Path
+from unittest import mock
+
+from solvent.delivery import make_delivery_token
+from solvent.server import create_app
+
+
+class TestHostedBriefs(unittest.TestCase):
+    def setUp(self):
+        self._env = mock.patch.dict(os.environ, {"SOLVENT_DELIVERY_SECRET": "x" * 32}, clear=False)
+        self._env.start()
+        self.reports_dir = Path(__file__).resolve().parent.parent / "data" / "reports"
+        self.reports_dir.mkdir(parents=True, exist_ok=True)
+        self.report_path = self.reports_dir / "victim-job.md"
+        self.report_path.write_text("# Private brief", encoding="utf-8")
+
+    def tearDown(self):
+        self.report_path.unlink(missing_ok=True)
+        self._env.stop()
+
+    def test_brief_serving_requires_exact_job_id_match(self):
+        try:
+            from fastapi.testclient import TestClient
+        except ImportError:
+            self.skipTest("FastAPI test client is not installed")
+
+        client = TestClient(create_app())
+        token = make_delivery_token("victim")
+        response = client.get(f"/briefs/victim?token={token}")
+        self.assertEqual(response.status_code, 404)
+
+        token = make_delivery_token("victim-job")
+        response = client.get(f"/briefs/victim-job?token={token}")
+        self.assertEqual(response.status_code, 200)
+        self.assertIn("Private brief", response.text)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_stages.py
+++ b/tests/test_stages.py
@@ -1,6 +1,7 @@
 """Tests for idempotent job stages."""
 
 import json
+import os
 import tempfile
 import unittest
 from pathlib import Path
@@ -11,6 +12,13 @@ from solvent.treasury import Treasury
 
 
 class TestStagesIdempotency(unittest.TestCase):
+    def setUp(self):
+        self._env = mock.patch.dict(os.environ, {"SOLVENT_DELIVERY_SECRET": "x" * 32}, clear=False)
+        self._env.start()
+
+    def tearDown(self):
+        self._env.stop()
+
     def test_double_paid_stage_does_not_double_earn(self):
         with tempfile.TemporaryDirectory() as tmp:
             db = Path(tmp) / "t.db"

--- a/tests/test_stripe_client.py
+++ b/tests/test_stripe_client.py
@@ -262,6 +262,13 @@ class TestStripeClientLive(unittest.TestCase):
 
 
 class TestAgentPaymentFlow(unittest.TestCase):
+    def setUp(self):
+        self._env = mock.patch.dict(os.environ, {"SOLVENT_DELIVERY_SECRET": "x" * 32}, clear=False)
+        self._env.start()
+
+    def tearDown(self):
+        self._env.stop()
+
     def test_agent_waits_for_payment_before_fulfil(self):
         from solvent.agent import Solvent
 


### PR DESCRIPTION
### Motivation
- The hosted brief endpoint relied on a default, public HMAC secret and a substring fallback for report lookup, allowing tokens to be forged and unrelated reports to be disclosed. 
- The server must fail closed when `SOLVENT_DELIVERY_SECRET` is missing or a known placeholder and only serve exact, safe report paths. 

### Description
- Require a configured, high-entropy `SOLVENT_DELIVERY_SECRET` (minimum 32 bytes) and reject known placeholder secrets by raising an error during token creation/verification (`solvent/delivery.py`).
- Add `is_safe_job_id()` to validate hosted-brief job IDs and reject unsafe IDs before token operations (`solvent/delivery.py`).
- Remove substring-based report lookup and serve only an exact resolved path under `data/reports`, with an extra directory-escape guard (`solvent/server.py`).
- Update production docs to show generating a secure secret and add tests that cover fail-closed secret handling, safe job IDs, and exact hosted-brief matching (`docs/PRODUCTION.md`, `tests/test_delivery.py`, new `tests/test_server.py`, and small test harness patches to ensure environment setup during tests). 

### Testing
- Ran `python -m unittest tests.test_delivery` and the delivery unit tests passed successfully.
- Compiled modules with `python -m compileall solvent tests` to verify syntax and imports and it completed without errors.
- Ran the full test suite with `python -m unittest`, which ran 53 tests with one FastAPI-dependent server test skipped (when `fastapi.testclient` is unavailable) and overall succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a336f57d49c8324b5ebbe6411b2778b)