### PR TITLE
Escape untrusted dashboard HTML fragments

### DIFF
--- a/solvent/dashboard.py
+++ b/solvent/dashboard.py
@@ -12,12 +12,28 @@ Includes:
 
 from __future__ import annotations
 
+import html
 import json
 import time
 from pathlib import Path
+from urllib.parse import urlparse
 from .treasury import fmt
 
 OUT = Path(__file__).resolve().parent.parent / "treasury_dashboard.html"
+
+
+def h(value: object) -> str:
+    """HTML-escape dashboard values before interpolating into fragments."""
+    return html.escape(str(value), quote=True)
+
+
+def safe_href(value: object) -> str:
+    """Return an escaped HTTP(S) URL or a harmless placeholder."""
+    url = str(value)
+    parsed = urlparse(url)
+    if parsed.scheme not in {"http", "https"}:
+        return "#"
+    return h(url)
 
 
 def generate_svg_chart(points: list[int]) -> str:
@@ -119,7 +135,7 @@ def render(snapshot: dict, log: list[dict]) -> Path:
         expense_breakdown_html += f"""
         <div class="vendor-metric">
           <div class="vendor-info">
-            <span class="vendor-name">{vendor}</span>
+            <span class="vendor-name">{h(vendor)}</span>
             <span class="vendor-amount">{fmt(amt)} ({pct:.1f}%)</span>
           </div>
           <div class="progress-bar-bg">
@@ -190,8 +206,11 @@ def render(snapshot: dict, log: list[dict]) -> Path:
         if not job["id"]:
             continue
         
-        status_class = job["status"]
-        status_label = job["status"].replace("_", " ").upper()
+        status_class = h(job["status"])
+        status_label = h(job["status"].replace("_", " ").upper())
+        jid_text = h(jid)
+        jid_js_arg = h(json.dumps(str(jid)))
+        job_title = h(job["title"] or "No Topic Provided")
         
         expense_total = sum(x["amount"] for x in job["expenses"])
         fin_pnl = job["price"] - expense_total if job["status"] == "completed" else 0
@@ -199,19 +218,19 @@ def render(snapshot: dict, log: list[dict]) -> Path:
         
         btn_html = ""
         if job["status"] == "completed":
-            btn_html = f"""<button class="btn btn-primary btn-sm" onclick="openDrawer('{jid}')">View Brief</button>"""
+            btn_html = f"""<button class="btn btn-primary btn-sm" onclick="openDrawer({jid_js_arg})">View Brief</button>"""
         elif job["status"] == "declined":
-            btn_html = f"""<span class="decline-label">Declined: {job['reason']}</span>"""
+            btn_html = f"""<span class="decline-label">Declined: {h(job['reason'])}</span>"""
         elif job["status"] == "awaiting_payment":
-            btn_html = f"""<a href="{job['invoice_url']}" target="_blank" class="btn btn-outline btn-sm">Pay Invoice</a>"""
+            btn_html = f"""<a href="{safe_href(job['invoice_url'])}" target="_blank" rel="noopener noreferrer" class="btn btn-outline btn-sm">Pay Invoice</a>"""
             
         job_cards_html += f"""
         <div class="job-card status-{status_class}">
           <div class="job-card-header">
-            <span class="job-id">{jid}</span>
+            <span class="job-id">{jid_text}</span>
             <span class="badge badge-{status_class}">{status_label}</span>
           </div>
-          <h3 class="job-title">{job['title'] or 'No Topic Provided'}</h3>
+          <h3 class="job-title">{job_title}</h3>
           
           <div class="job-metrics">
             <div class="job-metric-item">
@@ -243,32 +262,33 @@ def render(snapshot: dict, log: list[dict]) -> Path:
     for e in log:
         ts_str = time.strftime("%H:%M:%S", time.localtime(e.get("ts", time.time())))
         st = e["stage"]
-        job_ref = f"<span class='console-job-id'>[{e.get('job_id')}]</span>" if e.get("job_id") else ""
+        job_ref = f"<span class='console-job-id'>[{h(e.get('job_id'))}]</span>" if e.get("job_id") else ""
         
         if st == "quote":
             verdict = "<span class='green-txt'>ACCEPT</span>" if e["accept"] else "<span class='red-txt'>DECLINE</span>"
-            msg = f"Quoting topic: \"{e['title']}\" | Price: {fmt(e['price'])} | Est. Cost: {fmt(e['est_cost'])} | Margin: {e['margin_pct']}% → {verdict}"
+            msg = f"Quoting topic: \"{h(e['title'])}\" | Price: {fmt(e['price'])} | Est. Cost: {fmt(e['est_cost'])} | Margin: {h(e['margin_pct'])}% → {verdict}"
         elif st == "declined":
-            msg = f"✋ Declined job. Reason: <span class='grey-txt'>{e['reason']}</span>"
+            msg = f"✋ Declined job. Reason: <span class='grey-txt'>{h(e['reason'])}</span>"
         elif st == "invoice":
             tag = "simulated" if e["simulated"] else "live"
-            msg = f"📄 Issued Stripe Payment Link for {fmt(e['amount'])} ({tag}) → <a href='{e['url']}' target='_blank' class='console-link'>{e['url']}</a>"
+            url = safe_href(e["url"])
+            msg = f"📄 Issued Stripe Payment Link for {fmt(e['amount'])} ({tag}) → <a href='{url}' target='_blank' rel='noopener noreferrer' class='console-link'>{url}</a>"
         elif st == "paid":
             msg = f"💵 Stripe payment confirmed: <span class='green-txt'>+{fmt(e['amount'])}</span> received from client"
         elif st == "fulfilled":
-            msg = f"📝 Job fulfilled. Deliverable written to <span class='filepath-txt'>{Path(e['deliverable']).name}</span> ({e['tokens']} tokens)"
+            msg = f"📝 Job fulfilled. Deliverable written to <span class='filepath-txt'>{h(Path(e['deliverable']).name)}</span> ({h(e['tokens'])} tokens)"
         elif st == "spend":
-            msg = f"↳ Paid vendor <span class='vendor-badge'>{e['vendor']}</span>: <span class='red-txt'>−{fmt(e['amount'])}</span> ({e['memo']})"
+            msg = f"↳ Paid vendor <span class='vendor-badge'>{h(e['vendor'])}</span>: <span class='red-txt'>−{fmt(e['amount'])}</span> ({h(e['memo'])})"
         elif st == "spend_blocked":
-            msg = f"🛑 Spend BLOCKED by guardrail: {fmt(e['amount'])} to {e['vendor']} ({e['memo']})"
+            msg = f"🛑 Spend BLOCKED by guardrail: {fmt(e['amount'])} to {h(e['vendor'])} ({h(e['memo'])})"
         elif st == "refunded":
-            msg = f"↩️ Escrow Refunded: Returned <span class='red-txt'>{fmt(e['amount'])}</span> to customer ({e['reason']})"
+            msg = f"↩️ Escrow Refunded: Returned <span class='red-txt'>{fmt(e['amount'])}</span> to customer ({h(e['reason'])})"
         elif st == "booked":
             pnl_color = "green-txt" if e["job_pnl"] >= 0 else "red-txt"
             pnl_sign = "+" if e["job_pnl"] >= 0 else ""
             msg = f"✓ Booked P&L. Job net: <span class='{pnl_color}'>{pnl_sign}{fmt(e['job_pnl'])}</span> | Current Capital Balance: <span class='gold-txt'>{fmt(e['balance'])}</span>"
         else:
-            msg = str(e)
+            msg = h(e)
             
         console_log_html += f"""
         <div class="console-line">

--- a/tests/test_dashboard_security.py
+++ b/tests/test_dashboard_security.py
@@ -1,0 +1,75 @@
+"""Security tests for dashboard rendering."""
+
+import json
+from pathlib import Path
+
+from solvent import dashboard
+
+
+def test_dashboard_status_html_fragments_escape_untrusted_fields(tmp_path, monkeypatch):
+    fake_module = tmp_path / "pkg" / "dashboard.py"
+    fake_module.parent.mkdir()
+    fake_module.write_text("")
+    monkeypatch.setattr(dashboard, "__file__", str(fake_module))
+    monkeypatch.setattr(dashboard, "OUT", tmp_path / "treasury_dashboard.html")
+
+    payload = '<img src=x onerror="globalThis.__SOLVENT_XSS_POC=1">'
+    snapshot = {
+        "capital_cents": 10000,
+        "balance_cents": 12000,
+        "revenue_cents": 5000,
+        "expense_cents": 3000,
+        "net_profit_cents": 2000,
+        "margin_pct": 40.0,
+        "entries": [
+            {"kind": "capital", "amount_cents": 10000},
+            {"kind": "expense", "amount_cents": 3000, "vendor": payload},
+        ],
+    }
+    log = [
+        {
+            "stage": "quote",
+            "job_id": "J1",
+            "title": payload,
+            "price": 5000,
+            "est_cost": 3000,
+            "margin_pct": 40.0,
+            "accept": False,
+            "reason": payload,
+            "ts": 1,
+        },
+        {"stage": "declined", "job_id": "J1", "reason": payload, "ts": 2},
+        {
+            "stage": "invoice",
+            "job_id": "J1",
+            "amount": 5000,
+            "simulated": True,
+            "url": "javascript:alert(1)",
+            "ts": 2,
+        },
+        {
+            "stage": "spend_blocked",
+            "job_id": "J1",
+            "amount": 1000,
+            "vendor": payload,
+            "memo": payload,
+            "ts": 3,
+        },
+    ]
+
+    dashboard.render(snapshot, log)
+
+    status_path = tmp_path / "data" / "dashboard_status.json"
+    status = json.loads(status_path.read_text())
+    rendered_fragments = "".join(
+        [
+            status["expense_breakdown_html"],
+            status["job_cards_html"],
+            status["console_log_html"],
+        ]
+    )
+
+    assert payload not in rendered_fragments
+    assert "&lt;img src=x onerror=&quot;globalThis.__SOLVENT_XSS_POC=1&quot;&gt;" in rendered_fragments
+    assert "javascript:alert(1)" not in rendered_fragments
+    assert "href='#'" in rendered_fragments or 'href="#"' in rendered_fragments


### PR DESCRIPTION
### Motivation
- Fix a stored DOM XSS vector where generated HTML fragments (`job_cards_html`, `console_log_html`, `expense_breakdown_html`) were serialized into `data/dashboard_status.json` and later injected into the dashboard with `innerHTML` without escaping.
- Prevent attacker-controlled job/log/vendor fields and `javascript:` invoice URLs from ending up as executable markup when an operator opens or hosts the dashboard.

### Description
- Added an HTML-escaping helper `h()` and a `safe_href()` helper that only allows `http`/`https` URLs and otherwise returns `#` in `solvent/dashboard.py`.
- HTML-escaped untrusted fields before interpolating into fragments: vendor names in expense breakdowns, job fields (status, id, title, decline reason, invoice URL), and console log fields (job ids, titles, reasons, URLs, deliverable names, vendors, memos, and fallback log objects).
- Replaced direct `onclick` string interpolation with a JSON-escaped `jid` argument to `openDrawer` and added `rel="noopener noreferrer"` to external links to reduce risk.
- Added a regression test `tests/test_dashboard_security.py` that injects malicious payloads and asserts that raw `<img onerror=...>` is escaped and `javascript:` links are not emitted.

### Testing
- Ran `python -m py_compile solvent/dashboard.py` and `python -m py_compile tests/test_dashboard_security.py` to validate syntax, both succeeded.
- Ran the new regression test with `pytest tests/test_dashboard_security.py -q`, which passed.
- Ran the full test suite with `pytest -q`, which completed successfully (`97 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a33622e6864832496e3cc003dfba026)