### PR TITLE
Harden hosted brief delivery tokens

### DIFF
--- a/docs/PRODUCTION.md
+++ b/docs/PRODUCTION.md
@@ -15,7 +15,7 @@ pip install -r requirements.txt
 pip install -r requirements-serve.txt
 
 export SOLVENT_BASE_URL=http://127.0.0.1:8787
-export SOLVENT_DELIVERY_SECRET=change-me-in-production
+export SOLVENT_DELIVERY_SECRET=$(python3 -c "import secrets; print(secrets.token_urlsafe(48))")
 
 # Terminal 1 — API + webhooks + hosted briefs
 python3 -m solvent serve --port 8787
@@ -82,7 +82,7 @@ python3 -m solvent tune --apply
 | `STRIPE_API_KEY` | Test/restricted Stripe key |
 | `STRIPE_WEBHOOK_SECRET` | Webhook signature verification |
 | `SOLVENT_BASE_URL` | Checkout success URLs + hosted briefs |
-| `SOLVENT_DELIVERY_SECRET` | HMAC token for `/briefs/{id}` |
+| `SOLVENT_DELIVERY_SECRET` | HMAC token for `/briefs/{id}`; required, non-placeholder, at least 32 bytes |
 | `SOLVENT_ASYNC` | Non-blocking payment (worker resumes jobs) |
 | `SOLVENT_ALLOW_POLL` | Legacy payment polling |
 | `SOLVENT_LOG_JSON` | JSON lines to stderr + `data/solvent.log` |

--- a/solvent/delivery.py
+++ b/solvent/delivery.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import hashlib
 import hmac
 import os
+import re
 import smtplib
 import time
 from email.mime.multipart import MIMEMultipart
@@ -12,13 +13,31 @@ from email.mime.text import MIMEText
 from pathlib import Path
 
 OUTBOX_DIR = Path(__file__).resolve().parent.parent / "data" / "outbox"
+MIN_DELIVERY_SECRET_BYTES = 32
+INSECURE_DELIVERY_SECRETS = {"solvent-dev-secret-change-me", "change-me-in-production"}
+SAFE_JOB_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.-]{0,127}$")
+
+
+def is_safe_job_id(job_id: str) -> bool:
+    return bool(SAFE_JOB_ID_RE.fullmatch(job_id or ""))
 
 
 def _delivery_secret() -> str:
-    return os.environ.get("SOLVENT_DELIVERY_SECRET", "solvent-dev-secret-change-me")
+    secret = os.environ.get("SOLVENT_DELIVERY_SECRET", "").strip()
+    if (
+        len(secret.encode("utf-8")) < MIN_DELIVERY_SECRET_BYTES
+        or secret in INSECURE_DELIVERY_SECRETS
+    ):
+        raise RuntimeError(
+            "SOLVENT_DELIVERY_SECRET must be set to a non-placeholder value "
+            f"with at least {MIN_DELIVERY_SECRET_BYTES} bytes"
+        )
+    return secret
 
 
 def make_delivery_token(job_id: str, ts: float | None = None) -> str:
+    if not is_safe_job_id(job_id):
+        raise ValueError("unsafe job_id")
     ts = ts or time.time()
     payload = f"{job_id}:{int(ts)}"
     sig = hmac.new(_delivery_secret().encode(), payload.encode(), hashlib.sha256).hexdigest()
@@ -26,6 +45,8 @@ def make_delivery_token(job_id: str, ts: float | None = None) -> str:
 
 
 def verify_delivery_token(job_id: str, token: str, max_age_seconds: int = 7 * 86400) -> bool:
+    if not is_safe_job_id(job_id):
+        return False
     if not token or "." not in token:
         return False
     ts_str, sig = token.split(".", 1)
@@ -36,7 +57,10 @@ def verify_delivery_token(job_id: str, token: str, max_age_seconds: int = 7 * 86
     if abs(time.time() - ts) > max_age_seconds:
         return False
     payload = f"{job_id}:{ts}"
-    expected = hmac.new(_delivery_secret().encode(), payload.encode(), hashlib.sha256).hexdigest()
+    try:
+        expected = hmac.new(_delivery_secret().encode(), payload.encode(), hashlib.sha256).hexdigest()
+    except RuntimeError:
+        return False
     return hmac.compare_digest(expected, sig)
 
 

--- a/solvent/server.py
+++ b/solvent/server.py
@@ -7,7 +7,7 @@ import os
 from pathlib import Path
 
 from .agent import Solvent
-from .delivery import verify_delivery_token, markdown_to_html
+from .delivery import verify_delivery_token, markdown_to_html, is_safe_job_id
 from .stripe_client import StripeClient
 
 
@@ -61,13 +61,26 @@ def create_app(seed_cents: int = 10_000, fresh: bool = False) -> object:
 
     @app.get("/briefs/{job_id}")
     def get_brief(job_id: str, token: str = ""):
+        if not is_safe_job_id(job_id):
+            raise HTTPException(404, "brief not found")
         if not verify_delivery_token(job_id, token):
             raise HTTPException(403, "invalid or expired delivery token")
-        path = Path(__file__).resolve().parent.parent / "data" / "reports" / f"{job_id}.md"
+
+        reports_dir = (Path(__file__).resolve().parent.parent / "data" / "reports").resolve()
+        path = (reports_dir / f"{job_id}.md").resolve()
+        try:
+            path.relative_to(reports_dir)
+        except ValueError:
+            raise HTTPException(404, "brief not found")
+
         if not path.is_file():
-            for p in (Path(__file__).resolve().parent.parent / "data" / "reports").glob("*.md"):
-                if job_id in p.stem:
-                    path = p
+            for candidate in reports_dir.glob("*.md"):
+                if job_id in candidate.stem:
+                    path = candidate.resolve()
+                    try:
+                        path.relative_to(reports_dir)
+                    except ValueError:
+                        continue
                     break
         if not path.is_file():
             raise HTTPException(404, "brief not found")

--- a/tests/test_delivery.py
+++ b/tests/test_delivery.py
@@ -1,5 +1,6 @@
 """Tests for delivery tokens and outbox email."""
 
+import os
 import tempfile
 import unittest
 from pathlib import Path
@@ -13,10 +14,35 @@ from solvent.delivery import (
 
 
 class TestDelivery(unittest.TestCase):
+    def setUp(self):
+        self._old_secret = os.environ.get("SOLVENT_DELIVERY_SECRET")
+        os.environ["SOLVENT_DELIVERY_SECRET"] = "test-delivery-secret-with-more-than-32-bytes"
+
+    def tearDown(self):
+        if self._old_secret is None:
+            os.environ.pop("SOLVENT_DELIVERY_SECRET", None)
+        else:
+            os.environ["SOLVENT_DELIVERY_SECRET"] = self._old_secret
+
     def test_token_roundtrip(self):
         token = make_delivery_token("J1")
         self.assertTrue(verify_delivery_token("J1", token))
         self.assertFalse(verify_delivery_token("J2", token))
+
+    def test_rejects_missing_or_placeholder_secret(self):
+        os.environ.pop("SOLVENT_DELIVERY_SECRET", None)
+        self.assertFalse(verify_delivery_token("J1", "123.bad"))
+        with self.assertRaises(RuntimeError):
+            make_delivery_token("J1")
+        os.environ["SOLVENT_DELIVERY_SECRET"] = "change-me-in-production"
+        self.assertFalse(verify_delivery_token("J1", "123.bad"))
+        with self.assertRaises(RuntimeError):
+            make_delivery_token("J1")
+
+    def test_rejects_unsafe_job_ids(self):
+        with self.assertRaises(ValueError):
+            make_delivery_token("../J1")
+        self.assertFalse(verify_delivery_token("../J1", "123.bad"))
 
     def test_hosted_url(self):
         url = hosted_brief_url("http://localhost:8787", "J1")

--- a/tests/test_stages.py
+++ b/tests/test_stages.py
@@ -1,6 +1,7 @@
 """Tests for idempotent job stages."""
 
 import json
+import os
 import tempfile
 import unittest
 from pathlib import Path
@@ -11,6 +12,16 @@ from solvent.treasury import Treasury
 
 
 class TestStagesIdempotency(unittest.TestCase):
+    def setUp(self):
+        self._old_secret = os.environ.get("SOLVENT_DELIVERY_SECRET")
+        os.environ["SOLVENT_DELIVERY_SECRET"] = "test-delivery-secret-with-more-than-32-bytes"
+
+    def tearDown(self):
+        if self._old_secret is None:
+            os.environ.pop("SOLVENT_DELIVERY_SECRET", None)
+        else:
+            os.environ["SOLVENT_DELIVERY_SECRET"] = self._old_secret
+
     def test_double_paid_stage_does_not_double_earn(self):
         with tempfile.TemporaryDirectory() as tmp:
             db = Path(tmp) / "t.db"


### PR DESCRIPTION
### Motivation
- Close an authorization hole where a public fallback/placeholder `SOLVENT_DELIVERY_SECRET` allowed forged hosted brief tokens and unsafe job IDs to read arbitrary report files. 
- Restore fail-closed behavior so deployments without a proper secret do not sign or accept tokens.
- Prevent path containment and job-id injection risks when serving `/briefs/{job_id}`.

### Description
- Require `SOLVENT_DELIVERY_SECRET` to be set to a non-placeholder secret at least 32 bytes long and raise `RuntimeError` when it is missing or insecure, replacing the previous public fallback string in `solvent/delivery.py`.
- Add `is_safe_job_id()` with a strict regex and enforce it in `make_delivery_token()` and `verify_delivery_token()` to reject unsafe job IDs before signing or verifying HMACs.
- Reintroduce server-side containment checks in `solvent/server.py` by resolving `data/reports`, resolving candidate paths and using `path.relative_to(reports_dir)` to prevent reads outside the reports directory, and check `is_safe_job_id()` before attempting delivery.
- Update `docs/PRODUCTION.md` to stop recommending a known placeholder and instead generate a strong `SOLVENT_DELIVERY_SECRET` and document the non-placeholder/32-byte requirement.
- Add/adjust tests: `tests/test_delivery.py` now sets a valid secret in `setUp()` and adds tests for missing/placeholder secrets and unsafe job IDs; `tests/test_stages.py` is adjusted to set a valid secret during stage tests.

### Testing
- Ran unit tests for the modified areas with `python -m unittest tests/test_delivery.py tests/test_stages.py`, which passed (`OK`).
- Verified syntax with `python -m py_compile solvent/delivery.py solvent/server.py`, which succeeded.
- Ran full test discovery with `python -m unittest discover`, which surfaced one pre-existing unrelated failure in `tests.test_stripe_client.TestStripeClientLive.test_confirm_payment_awaits_webhook_by_default` (assertion about the failure reason string); this failure is not caused by the delivery hardening changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a34140079448324a81404ceb81147d2)