### PR TITLE
Secure hosted brief delivery tokens

### DIFF
--- a/docs/PRODUCTION.md
+++ b/docs/PRODUCTION.md
@@ -15,7 +15,7 @@ pip install -r requirements.txt
 pip install -r requirements-serve.txt
 
 export SOLVENT_BASE_URL=http://127.0.0.1:8787
-export SOLVENT_DELIVERY_SECRET=change-me-in-production
+export SOLVENT_DELIVERY_SECRET=$(python3 -c 'import secrets; print(secrets.token_urlsafe(48))')
 
 # Terminal 1 — API + webhooks + hosted briefs
 python3 -m solvent serve --port 8787
@@ -82,7 +82,7 @@ python3 -m solvent tune --apply
 | `STRIPE_API_KEY` | Test/restricted Stripe key |
 | `STRIPE_WEBHOOK_SECRET` | Webhook signature verification |
 | `SOLVENT_BASE_URL` | Checkout success URLs + hosted briefs |
-| `SOLVENT_DELIVERY_SECRET` | HMAC token for `/briefs/{id}` |
+| `SOLVENT_DELIVERY_SECRET` | HMAC token for `/briefs/{id}`; required, at least 32 characters, high entropy, and not a placeholder |
 | `SOLVENT_ASYNC` | Non-blocking payment (worker resumes jobs) |
 | `SOLVENT_ALLOW_POLL` | Legacy payment polling |
 | `SOLVENT_LOG_JSON` | JSON lines to stderr + `data/solvent.log` |

--- a/solvent/delivery.py
+++ b/solvent/delivery.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import hashlib
 import hmac
 import os
+import re
 import smtplib
 import time
 from email.mime.multipart import MIMEMultipart
@@ -12,13 +13,30 @@ from email.mime.text import MIMEText
 from pathlib import Path
 
 OUTBOX_DIR = Path(__file__).resolve().parent.parent / "data" / "outbox"
+_SAFE_JOB_ID = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_-]{0,127}$")
+_PLACEHOLDER_DELIVERY_SECRETS = {
+    "solvent-dev-secret-change-me",
+    "change-me-in-production",
+}
+
+
+def is_safe_job_id(job_id: str) -> bool:
+    return bool(_SAFE_JOB_ID.fullmatch(job_id))
 
 
 def _delivery_secret() -> str:
-    return os.environ.get("SOLVENT_DELIVERY_SECRET", "solvent-dev-secret-change-me")
+    secret = os.environ.get("SOLVENT_DELIVERY_SECRET", "").strip()
+    if len(secret) < 32 or secret in _PLACEHOLDER_DELIVERY_SECRETS:
+        raise RuntimeError(
+            "SOLVENT_DELIVERY_SECRET must be set to a non-placeholder value "
+            "with at least 32 characters"
+        )
+    return secret
 
 
 def make_delivery_token(job_id: str, ts: float | None = None) -> str:
+    if not is_safe_job_id(job_id):
+        raise ValueError("unsafe job_id")
     ts = ts or time.time()
     payload = f"{job_id}:{int(ts)}"
     sig = hmac.new(_delivery_secret().encode(), payload.encode(), hashlib.sha256).hexdigest()
@@ -26,7 +44,7 @@ def make_delivery_token(job_id: str, ts: float | None = None) -> str:
 
 
 def verify_delivery_token(job_id: str, token: str, max_age_seconds: int = 7 * 86400) -> bool:
-    if not token or "." not in token:
+    if not is_safe_job_id(job_id) or not token or "." not in token:
         return False
     ts_str, sig = token.split(".", 1)
     try:
@@ -36,7 +54,11 @@ def verify_delivery_token(job_id: str, token: str, max_age_seconds: int = 7 * 86
     if abs(time.time() - ts) > max_age_seconds:
         return False
     payload = f"{job_id}:{ts}"
-    expected = hmac.new(_delivery_secret().encode(), payload.encode(), hashlib.sha256).hexdigest()
+    try:
+        secret = _delivery_secret()
+    except RuntimeError:
+        return False
+    expected = hmac.new(secret.encode(), payload.encode(), hashlib.sha256).hexdigest()
     return hmac.compare_digest(expected, sig)
 
 

--- a/solvent/server.py
+++ b/solvent/server.py
@@ -7,7 +7,7 @@ import os
 from pathlib import Path
 
 from .agent import Solvent
-from .delivery import verify_delivery_token, markdown_to_html
+from .delivery import verify_delivery_token, markdown_to_html, is_safe_job_id
 from .stripe_client import StripeClient
 
 
@@ -61,14 +61,16 @@ def create_app(seed_cents: int = 10_000, fresh: bool = False) -> object:
 
     @app.get("/briefs/{job_id}")
     def get_brief(job_id: str, token: str = ""):
+        if not is_safe_job_id(job_id):
+            raise HTTPException(404, "brief not found")
         if not verify_delivery_token(job_id, token):
             raise HTTPException(403, "invalid or expired delivery token")
-        path = Path(__file__).resolve().parent.parent / "data" / "reports" / f"{job_id}.md"
-        if not path.is_file():
-            for p in (Path(__file__).resolve().parent.parent / "data" / "reports").glob("*.md"):
-                if job_id in p.stem:
-                    path = p
-                    break
+        reports_dir = (Path(__file__).resolve().parent.parent / "data" / "reports").resolve()
+        path = (reports_dir / f"{job_id}.md").resolve()
+        try:
+            path.relative_to(reports_dir)
+        except ValueError:
+            raise HTTPException(404, "brief not found") from None
         if not path.is_file():
             raise HTTPException(404, "brief not found")
         return HTMLResponse(markdown_to_html(path.read_text(encoding="utf-8")))

--- a/tests/test_delivery.py
+++ b/tests/test_delivery.py
@@ -1,7 +1,9 @@
 """Tests for delivery tokens and outbox email."""
 
+import os
 import tempfile
 import unittest
+from unittest import mock
 from pathlib import Path
 
 from solvent.delivery import (
@@ -13,10 +15,33 @@ from solvent.delivery import (
 
 
 class TestDelivery(unittest.TestCase):
+    def setUp(self):
+        self._env = mock.patch.dict(os.environ, {"SOLVENT_DELIVERY_SECRET": "x" * 32}, clear=False)
+        self._env.start()
+
+    def tearDown(self):
+        self._env.stop()
+
     def test_token_roundtrip(self):
         token = make_delivery_token("J1")
         self.assertTrue(verify_delivery_token("J1", token))
         self.assertFalse(verify_delivery_token("J2", token))
+
+    def test_rejects_missing_or_placeholder_secret(self):
+        with mock.patch.dict(os.environ, {}, clear=True):
+            with self.assertRaises(RuntimeError):
+                make_delivery_token("J1")
+            self.assertFalse(verify_delivery_token("J1", "123.bad"))
+
+        with mock.patch.dict(os.environ, {"SOLVENT_DELIVERY_SECRET": "change-me-in-production"}, clear=True):
+            with self.assertRaises(RuntimeError):
+                make_delivery_token("J1")
+            self.assertFalse(verify_delivery_token("J1", "123.bad"))
+
+    def test_rejects_unsafe_job_id(self):
+        with self.assertRaises(ValueError):
+            make_delivery_token("../J1")
+        self.assertFalse(verify_delivery_token("../J1", "123.bad"))
 
     def test_hosted_url(self):
         url = hosted_brief_url("http://localhost:8787", "J1")

--- a/tests/test_stages.py
+++ b/tests/test_stages.py
@@ -45,14 +45,15 @@ class TestStagesIdempotency(unittest.TestCase):
             }
             Path(fulfill["deliverable_path"]).write_text("# brief")
 
-            with mock.patch.object(agent.stripe, "create_checkout_session", return_value=link):
-                with mock.patch.object(agent.stripe, "confirm_payment", return_value=payment):
-                    with mock.patch("solvent.service.fulfill", return_value=fulfill):
-                        with mock.patch("solvent.delivery.send_brief_email", return_value={"simulated": True}):
-                            agent.handle_job(job)
-                            rev1 = len([e for e in agent.t.entries if e.kind == "revenue" and e.job_id == "J-idem"])
-                            agent._runner._stage_paid(job, link, agent._runner._stage_quote(job).get("_quote") or mock.Mock(price_cents=5000, est_cost_cents=100, margin_cents=4900, margin_pct=90))
-                            rev2 = len([e for e in agent.t.entries if e.kind == "revenue" and e.job_id == "J-idem"])
+            with mock.patch.dict("os.environ", {"SOLVENT_DELIVERY_SECRET": "x" * 32}, clear=False):
+                with mock.patch.object(agent.stripe, "create_checkout_session", return_value=link):
+                    with mock.patch.object(agent.stripe, "confirm_payment", return_value=payment):
+                        with mock.patch("solvent.service.fulfill", return_value=fulfill):
+                            with mock.patch("solvent.delivery.send_brief_email", return_value={"simulated": True}):
+                                agent.handle_job(job)
+                                rev1 = len([e for e in agent.t.entries if e.kind == "revenue" and e.job_id == "J-idem"])
+                                agent._runner._stage_paid(job, link, agent._runner._stage_quote(job).get("_quote") or mock.Mock(price_cents=5000, est_cost_cents=100, margin_cents=4900, margin_pct=90))
+                                rev2 = len([e for e in agent.t.entries if e.kind == "revenue" and e.job_id == "J-idem"])
             self.assertEqual(rev1, 1)
             self.assertEqual(rev2, 1)
 


### PR DESCRIPTION
### Motivation
- Fix a security regression where hosted brief tokens could be forged due to a public/default HMAC secret, permissive job-id handling, and substring-based report fallback that could disclose other reports.
- Restore fail-closed behavior for delivery authentication and safe file resolution to prevent remote attackers from forging access to briefs.

### Description
- Require `SOLVENT_DELIVERY_SECRET` to be explicitly configured and non-placeholder, raising a `RuntimeError` if unset, too short, or a known placeholder, and refuse to sign tokens otherwise (`solvent/delivery.py`).
- Add `is_safe_job_id()` with a conservative regex and validate `job_id` before token creation or verification, rejecting unsafe job IDs (`solvent/delivery.py`).
- Harden `/briefs/{job_id}` serving by rejecting unsafe job IDs, resolving the report path under `data/reports` via `Path.resolve()` and `relative_to()` containment checks, and remove the substring-based fallback lookup (`solvent/server.py`).
- Update `docs/PRODUCTION.md` to instruct operators to generate a high-entropy delivery secret and clarify the requirement (>=32 chars, non-placeholder), and add/adjust unit tests to cover missing/placeholder secrets and unsafe job IDs (`tests/test_delivery.py`, `tests/test_stages.py`).

### Testing
- Ran `python3 -m unittest tests/test_delivery.py tests/test_server.py tests/test_stages.py`, which passed (OK, one test skipped).
- Ran `python3 -m unittest` for the full suite and observed an unrelated existing failure in `tests.test_stripe_client.TestStripeClientLive.test_confirm_payment_awaits_webhook_by_default`, where the assertion expected a reason containing `webhook` but got `payment not received within 0s`.
- Performed a `git diff --check` to validate whitespace and diffs (no issues).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a3412dcc45c8324bb1853370e953beb)