### PR TITLE
Add cross-process chat outbox for worker-to-serve notifications

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,7 @@ data/reports/*.pdf
 # Runtime logs and email outbox (delivery + observability)
 data/solvent.log
 data/outbox/
+data/chat_outbox.jsonl
 
 # Keep the data/reports directory structures but ignore content
 !data/

--- a/solvent/gateway.py
+++ b/solvent/gateway.py
@@ -25,6 +25,11 @@ def notify(channel: str, external_id: str, text: str) -> None:
     handler = _outbound_handlers.get(channel)
     if handler:
         handler(external_id, text)
+    try:
+        from .notifications import enqueue_chat
+        enqueue_chat(channel, external_id, text)
+    except Exception:
+        pass
 
 
 def _rate_ok(user_key: str) -> bool:

--- a/solvent/notifications.py
+++ b/solvent/notifications.py
@@ -1,0 +1,60 @@
+"""Cross-process chat notifications via append-only JSONL outbox."""
+
+from __future__ import annotations
+
+import json
+import os
+import time
+from pathlib import Path
+
+_OUTBOX = Path(__file__).resolve().parent.parent / "data" / "chat_outbox.jsonl"
+_LOCK = Path(__file__).resolve().parent.parent / "data" / "chat_outbox.lock"
+
+
+class _LockCtx:
+    def __enter__(self):
+        import fcntl
+
+        _LOCK.parent.mkdir(parents=True, exist_ok=True)
+        self._fd = os.open(_LOCK, os.O_CREAT | os.O_RDWR)
+        fcntl.flock(self._fd, fcntl.LOCK_EX)
+        return self
+
+    def __exit__(self, *args):
+        import fcntl
+
+        fcntl.flock(self._fd, fcntl.LOCK_UN)
+        os.close(self._fd)
+
+
+def enqueue_chat(channel: str, external_id: str, text: str) -> None:
+    """Append a chat notification for another process (e.g. serve) to deliver."""
+    row = {
+        "channel": channel,
+        "external_id": external_id,
+        "text": text,
+        "ts": time.time(),
+    }
+    _OUTBOX.parent.mkdir(parents=True, exist_ok=True)
+    with _LockCtx():
+        with _OUTBOX.open("a", encoding="utf-8") as fh:
+            fh.write(json.dumps(row, separators=(",", ":")) + "\n")
+
+
+def drain_chat_outbox() -> list[dict]:
+    """Return and remove all pending outbox rows (best-effort, file-locked)."""
+    if not _OUTBOX.is_file():
+        return []
+    with _LockCtx():
+        raw = _OUTBOX.read_text(encoding="utf-8")
+        _OUTBOX.write_text("", encoding="utf-8")
+    rows: list[dict] = []
+    for line in raw.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            rows.append(json.loads(line))
+        except json.JSONDecodeError:
+            continue
+    return rows

--- a/solvent/workspace.py
+++ b/solvent/workspace.py
@@ -310,7 +310,7 @@ def build_system_prompt(
 
 def build_chat_system_prompt(channel: str = "cli") -> str:
     """Gateway/chat entry — private channels get MEMORY.md."""
-    session_kind = "main" if channel in ("cli", "telegram", "interactive") else "shared"
+    session_kind = "main" if channel in ("cli", "telegram", "interactive", "dashboard") else "shared"
     return build_system_prompt(session_kind=session_kind)
 
 

--- a/tests/test_notifications.py
+++ b/tests/test_notifications.py
@@ -1,0 +1,51 @@
+"""Tests for cross-process chat outbox."""
+
+import json
+import os
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from solvent import notifications as n
+
+
+class TestChatOutbox(unittest.TestCase):
+    def setUp(self):
+        self._tmpdir = tempfile.TemporaryDirectory()
+        base = Path(self._tmpdir.name)
+        self.outbox = base / "chat_outbox.jsonl"
+        self.lock = base / "chat_outbox.lock"
+        self._patch_outbox = mock.patch.object(n, "_OUTBOX", self.outbox)
+        self._patch_lock = mock.patch.object(n, "_LOCK", self.lock)
+        self._patch_outbox.start()
+        self._patch_lock.start()
+
+    def tearDown(self):
+        self._patch_lock.stop()
+        self._patch_outbox.stop()
+        self._tmpdir.cleanup()
+
+    def test_enqueue_and_drain(self):
+        n.enqueue_chat("dashboard", "sess-1", "Job J1 fulfilled.")
+        n.enqueue_chat("telegram", "12345", "Payment received.")
+        rows = n.drain_chat_outbox()
+        self.assertEqual(len(rows), 2)
+        self.assertEqual(rows[0]["channel"], "dashboard")
+        self.assertEqual(rows[0]["external_id"], "sess-1")
+        self.assertEqual(rows[1]["text"], "Payment received.")
+        self.assertEqual(n.drain_chat_outbox(), [])
+
+    def test_drain_empty(self):
+        self.assertEqual(n.drain_chat_outbox(), [])
+
+    def test_skips_bad_lines(self):
+        self.outbox.parent.mkdir(parents=True, exist_ok=True)
+        self.outbox.write_text('not json\n{"channel":"c","external_id":"1","text":"ok","ts":1}\n', encoding="utf-8")
+        rows = n.drain_chat_outbox()
+        self.assertEqual(len(rows), 1)
+        self.assertEqual(rows[0]["text"], "ok")


### PR DESCRIPTION
## Summary
- Adds `solvent/notifications.py` (`enqueue_chat` / `drain_chat_outbox`) — fixes missing module referenced by `server.py`
- Gateway writes outbound chat to JSONL; `serve` polls and pushes to SSE
- Dashboard channel uses private workspace memory
- Ignores `data/chat_outbox.jsonl` at runtime

## Test plan
- [x] `pytest tests/test_notifications.py tests/test_server.py -q`

Made with [Cursor](https://cursor.com)