### PR TITLE
Harden the agent tool-calling loop and spend guardrails

### DIFF
--- a/solvent/chat.py
+++ b/solvent/chat.py
@@ -194,6 +194,8 @@ def handle_message(
         user += f"\n{slot_hint}\n"
     user += f"\nUser: {text}"
 
+    tool_budget = tools.MAX_TOOL_CALLS
+    calls_made = 0
     for _ in range(6):
         reply, _ = nemotron.complete(system_prompt, user)
         calls = nemotron.parse_tool_calls(reply)
@@ -202,7 +204,14 @@ def handle_message(
             return reply
         notes = []
         for name, args in calls:
+            if calls_made >= tool_budget:
+                notes.append(
+                    f"[budget] per-turn tool-call limit ({tool_budget}) reached; "
+                    "answer the user now without more tool calls."
+                )
+                break
             result = registry.dispatch(name, args)
+            calls_made += 1
             notes.append(f"[{name}] {result}")
         user = user + f"\n\nAssistant: {reply}\n\nTool results:\n" + "\n".join(notes)
 

--- a/solvent/dashboard.py
+++ b/solvent/dashboard.py
@@ -310,7 +310,9 @@ def build_status_data(snapshot: dict, log: list[dict]) -> dict:
         elif st == "spend":
             msg = f"↳ Paid vendor <span class='vendor-badge'>{h(e['vendor'])}</span>: <span class='red-txt'>−{fmt(e['amount'])}</span> ({h(e['memo'])})"
         elif st == "spend_blocked":
-            msg = f"🛑 Spend BLOCKED by guardrail: {fmt(e['amount'])} to {h(e['vendor'])} ({h(e['memo'])})"
+            _why = e.get("reason") or e.get("rule")
+            _why_txt = f" — {h(_why)}" if _why else ""
+            msg = f"🛑 Spend BLOCKED by guardrail: {fmt(e['amount'])} to {h(e['vendor'])} ({h(e['memo'])}){_why_txt}"
         elif st == "refunded":
             msg = f"↩️ Escrow Refunded: Returned <span class='red-txt'>{fmt(e['amount'])}</span> to customer ({h(e['reason'])})"
         elif st == "booked":

--- a/solvent/guardrails.py
+++ b/solvent/guardrails.py
@@ -55,6 +55,36 @@ class GuardrailError(Exception):
     pass
 
 
+@dataclass
+class Decision:
+    """A structured, auditable spend-policy decision.
+
+    Modelled on policy-engine decision objects (OPA/Cedar): rather than
+    collapsing to a bare bool, every evaluation records *which* rule fired and
+    *why*, plus the context it was evaluated against, so the audit trail and
+    dashboard can explain a block.
+    """
+
+    allowed: bool
+    rule: str | None = None          # machine-readable rule id that denied
+    reason: str = "approved"         # human-readable explanation
+    amount_cents: int = 0
+    vendor: str = ""
+    spent_24h_cents: int = 0
+    balance_cents: int = 0
+
+    def as_dict(self) -> dict:
+        return {
+            "allowed": self.allowed,
+            "rule": self.rule,
+            "reason": self.reason,
+            "amount_cents": self.amount_cents,
+            "vendor": self.vendor,
+            "spent_24h_cents": self.spent_24h_cents,
+            "balance_cents": self.balance_cents,
+        }
+
+
 class Guardrails:
     """Enforces deterministic spend safety policies on all transaction requests."""
 
@@ -80,6 +110,51 @@ class Guardrails:
             if e.kind == "expense" and e.ts >= cutoff
         )
 
+    def evaluate(
+        self,
+        amount_cents: int,
+        vendor: str,
+        projected_job_margin_cents: int | None = None,
+    ) -> Decision:
+        """Evaluate a proposed spend against every policy rule.
+
+        Rules are checked in priority order and the *first* violation is
+        returned. The treasury is read once so the decision reflects a single
+        consistent snapshot. Returns a :class:`Decision` either way (never
+        raises); use :meth:`check_spend` for the raising variant.
+        """
+        spent_24h = self._spent_last_24h()
+        balance = self.t.balance_cents()
+        ctx = dict(
+            amount_cents=amount_cents,
+            vendor=vendor,
+            spent_24h_cents=spent_24h,
+            balance_cents=balance,
+        )
+
+        if vendor not in self.policy.vendor_allowlist:
+            return Decision(False, "vendor_allowlist", f"vendor '{vendor}' not on allowlist", **ctx)
+
+        if amount_cents > self.policy.max_txn_cents:
+            return Decision(
+                False, "max_txn_cap",
+                f"txn {amount_cents}c exceeds per-transaction cap {self.policy.max_txn_cents}c",
+                **ctx,
+            )
+
+        if spent_24h + amount_cents > self.policy.daily_budget_cents:
+            return Decision(False, "daily_budget", "would exceed 24h spend budget", **ctx)
+
+        if balance - amount_cents < self.policy.min_reserve_cents:
+            return Decision(False, "min_reserve", "would breach minimum cash reserve", **ctx)
+
+        if projected_job_margin_cents is not None and projected_job_margin_cents <= 0:
+            return Decision(
+                False, "roi", "job projected to be unprofitable; refusing to spend", **ctx
+            )
+
+        return Decision(True, None, "approved", **ctx)
+
     def check_spend(self, amount_cents: int, vendor: str, projected_job_margin_cents: int | None = None) -> None:
         """Raise GuardrailError if the spend violates policy. Returns None if OK.
 
@@ -91,22 +166,9 @@ class Guardrails:
         Raises:
             GuardrailError: If any of the spend policies are violated.
         """
-        if vendor not in self.policy.vendor_allowlist:
-            raise GuardrailError(f"vendor '{vendor}' not on allowlist")
-
-        if amount_cents > self.policy.max_txn_cents:
-            raise GuardrailError(
-                f"txn {amount_cents}c exceeds per-transaction cap {self.policy.max_txn_cents}c"
-            )
-
-        if self._spent_last_24h() + amount_cents > self.policy.daily_budget_cents:
-            raise GuardrailError("would exceed 24h spend budget")
-
-        if self.t.balance_cents() - amount_cents < self.policy.min_reserve_cents:
-            raise GuardrailError("would breach minimum cash reserve")
-
-        if projected_job_margin_cents is not None and projected_job_margin_cents <= 0:
-            raise GuardrailError("job projected to be unprofitable; refusing to spend")
+        decision = self.evaluate(amount_cents, vendor, projected_job_margin_cents)
+        if not decision.allowed:
+            raise GuardrailError(decision.reason)
 
     def approve(self, amount_cents: int, vendor: str, projected_job_margin_cents: int | None = None) -> bool:
         """Screen an outbound payment and return True if approved, False if blocked.
@@ -119,9 +181,5 @@ class Guardrails:
         Returns:
             True if the payment is approved, False otherwise.
         """
-        try:
-            self.check_spend(amount_cents, vendor, projected_job_margin_cents)
-            return True
-        except GuardrailError:
-            return False
+        return self.evaluate(amount_cents, vendor, projected_job_margin_cents).allowed
 

--- a/solvent/nemotron.py
+++ b/solvent/nemotron.py
@@ -243,18 +243,17 @@ def _expand(obj) -> list[tuple[str, dict]]:
     return out
 
 
-def _objects_at(text: str, positions) -> list[tuple[int, int, object]]:
-    """Parse a balanced JSON object at each ``{``; yield (start, end, value)."""
-    found: list[tuple[int, int, object]] = []
-    for i in positions:
-        end = _find_balanced(text, i)
-        if end == -1:
-            continue
-        try:
-            found.append((i, end, json.loads(text[i:end])))
-        except json.JSONDecodeError:
-            continue
-    return found
+def _strip_code_fence(s: str) -> str:
+    """Remove a single surrounding markdown code fence, if present."""
+    s = s.strip()
+    if s.startswith("```"):
+        nl = s.find("\n")
+        if nl != -1:
+            s = s[nl + 1:]
+        s = s.rstrip()
+        if s.endswith("```"):
+            s = s[:-3]
+    return s.strip()
 
 
 def parse_tool_calls(text: str) -> list[tuple[str, dict]]:
@@ -262,14 +261,16 @@ def parse_tool_calls(text: str) -> list[tuple[str, dict]]:
 
     Recognises, in priority order:
 
-    * Hermes/Nous ``<tool_call>{...}</tool_call>`` blocks
-    * Markdown ```` ```json ```` fenced blocks wrapping a call object
+    * Hermes/Nous ``<tool_call>{...}</tool_call>`` blocks (any number)
     * Legacy ``TOOL_CALL: name {json}`` lines (name outside the JSON)
-    * A bare JSON call object as a last-resort fallback
+    * As a fallback *only* when no marker matched and the whole message is a
+      single JSON object: a bare or ```` ```json ```` fenced call / OpenAI
+      ``{"tool_calls": [...]}`` envelope.
 
     Brace matching is balanced (handles nested ``arguments`` objects), multiple
     calls are returned in document order, and ``arguments`` supplied as a JSON
-    string is decoded. Anything unparseable is skipped rather than raised.
+    string is decoded. JSON merely *embedded* in prose or a brief is never
+    mistaken for a call. Anything unparseable is skipped rather than raised.
     """
     if not text:
         return []
@@ -321,27 +322,21 @@ def parse_tool_calls(text: str) -> list[tuple[str, dict]]:
         results.append((m.start(), m.group(1), args))
         _claim(m.start(), claim_end)
 
-    # 3. Bare / fenced JSON call objects for any region not already claimed.
-    #    To avoid mistaking ordinary JSON in the brief for a call, a bare object
-    #    must carry an explicit arguments key (or be an OpenAI/list envelope).
-    brace_positions = [
-        i for i, c in enumerate(text) if c == "{" and not _overlaps(i)
-    ]
-    for start, end, obj in _objects_at(text, brace_positions):
-        if _overlaps(start):
-            continue
-        if isinstance(obj, dict) and not (
-            isinstance(obj.get("tool_calls"), list)
-            or isinstance(obj.get("function"), dict)
-            or any(k in obj for k in ("arguments", "parameters", "args"))
-        ):
-            continue
-        calls = _expand(obj)
-        if not calls:
-            continue
-        for name, args in calls:
-            results.append((start, name, args))
-        _claim(start, end)
+    # 3. Bare / fenced JSON fallback — ONLY when no explicit marker matched and
+    #    the entire (fence-stripped) message *is* a single JSON object. This
+    #    supports models that reply with just an OpenAI-style call or a fenced
+    #    block, without mistaking illustrative JSON embedded in prose/a brief for
+    #    a tool call.
+    if not results:
+        whole = _strip_code_fence(text)
+        if whole.startswith("{") and _find_balanced(whole, 0) == len(whole):
+            try:
+                obj = json.loads(whole)
+            except json.JSONDecodeError:
+                obj = None
+            if obj is not None:
+                for name, args in _expand(obj):
+                    results.append((0, name, args))
 
     results.sort(key=lambda r: r[0])
     return [(name, args) for _, name, args in results]
@@ -354,10 +349,12 @@ def research_brief(topic: str, context: str = "n/a") -> tuple[str, dict, tools.T
     notes: list[str] = []
     system = (
         "You are SOLVENT, a disciplined sell-side research analyst. "
-        "You may request tools using TOOL_CALL: tool_name {\"arg\": \"value\"}. "
+        "To call a tool, emit a Hermes tool call: "
+        "<tool_call>{\"name\": \"tool_name\", \"arguments\": {\"arg\": \"value\"}}</tool_call>. "
         "Allowed tools: web_search, market_data, summarize. "
         "Do not request payment or treasury actions. "
-        "After gathering evidence, write the final brief with markdown headings."
+        "After gathering evidence, write the final brief with markdown headings "
+        "(no tool calls in the final answer)."
     )
     user = f"Research topic: {topic}\nClient context: {context}\n\nBegin research."
 

--- a/solvent/nemotron.py
+++ b/solvent/nemotron.py
@@ -368,6 +368,7 @@ def research_brief(topic: str, context: str = "n/a") -> tuple[str, dict, tools.T
             continue
         for name, args in matches:
             if ctx.total_calls >= tools.MAX_TOOL_CALLS:
+                ctx.budget_exhausted = True
                 break
             try:
                 result = tools.dispatch(

--- a/solvent/nemotron.py
+++ b/solvent/nemotron.py
@@ -12,12 +12,35 @@ from __future__ import annotations
 import json
 import os
 import re
+import time
+import urllib.error
 import urllib.request
 
 from . import tools
 
 MODEL = os.environ.get("NEMOTRON_MODEL", "nvidia/llama-3.1-nemotron-ultra-253b-v1")
 ENDPOINT = "https://integrate.api.nvidia.com/v1/chat/completions"
+
+
+def _int_env(name: str, default: int) -> int:
+    try:
+        return int(os.environ.get(name, "").strip() or default)
+    except ValueError:
+        return default
+
+
+# Bounded retry for transient upstream failures (rate limits, 5xx, timeouts).
+MAX_RETRIES = _int_env("NEMOTRON_MAX_RETRIES", 2)
+RETRY_BASE_DELAY = 0.5  # seconds; doubled each attempt
+
+
+def _is_transient(exc: Exception) -> bool:
+    """True if ``exc`` is worth retrying (rate limit, server error, network)."""
+    if isinstance(exc, urllib.error.HTTPError):
+        return exc.code == 429 or 500 <= exc.code < 600
+    if isinstance(exc, urllib.error.URLError):
+        return True  # DNS / connection reset / TLS hiccup
+    return isinstance(exc, (TimeoutError, ConnectionError))
 
 _force_offline = False
 
@@ -40,7 +63,8 @@ def _estimate_tokens(system: str, user: str, text: str) -> dict:
     }
 
 
-def _live_complete(system: str, user: str) -> tuple[str, dict]:
+def _live_request(system: str, user: str) -> dict:
+    """Single HTTP round-trip to the Nemotron endpoint. Raises on failure."""
     key = os.environ["NVIDIA_API_KEY"]
     body = json.dumps({
         "model": MODEL,
@@ -56,7 +80,23 @@ def _live_complete(system: str, user: str) -> tuple[str, dict]:
         headers={"Authorization": f"Bearer {key}", "Content-Type": "application/json"},
     )
     with urllib.request.urlopen(req, timeout=60) as r:
-        data = json.loads(r.read())
+        return json.loads(r.read())
+
+
+def _live_complete(system: str, user: str) -> tuple[str, dict]:
+    # Retry transient upstream failures with exponential backoff before the
+    # caller falls back to the offline stub. Permanent errors (bad key, 4xx)
+    # raise immediately so we don't waste time or mask a real misconfiguration.
+    attempt = 0
+    while True:
+        try:
+            data = _live_request(system, user)
+            break
+        except Exception as exc:
+            if attempt >= MAX_RETRIES or not _is_transient(exc):
+                raise
+            time.sleep(RETRY_BASE_DELAY * (2 ** attempt))
+            attempt += 1
     text = data["choices"][0]["message"]["content"]
     usage = data.get("usage") or {}
     if usage:
@@ -107,31 +147,204 @@ def complete(system: str, user: str) -> tuple[str, dict]:
     return text, _estimate_tokens(system, user, text)
 
 
-_TOOL_CALL_RE = re.compile(
-    r"TOOL_CALL:\s*(\w+)\s*(\{.*?\})",
-    re.DOTALL,
-)
-_HERMES_TOOL_RE = re.compile(
-    r"<tool_call>\s*(\{.*?\})\s*</tool_call>",
-    re.DOTALL,
-)
+# Markers that wrap an explicit tool-call payload. We prefer these over a bare
+# JSON scan because they are unambiguous and avoid false positives from JSON
+# that happens to appear inside the brief itself.
+_HERMES_OPEN_RE = re.compile(r"<tool_call>", re.IGNORECASE)
+_LEGACY_NAME_RE = re.compile(r"TOOL_CALL:\s*([A-Za-z_]\w*)\s*", re.IGNORECASE)
+
+
+def _find_balanced(text: str, start: int) -> int:
+    """Return the index just past the ``{...}`` object beginning at ``start``.
+
+    Walks the string honouring quoted strings and escapes so nested objects
+    (e.g. ``{"arguments": {"a": 1}}``) are matched correctly. Returns ``-1`` if
+    the braces never balance. ``text[start]`` must be ``{``.
+    """
+    depth = 0
+    in_str = False
+    esc = False
+    for j in range(start, len(text)):
+        c = text[j]
+        if in_str:
+            if esc:
+                esc = False
+            elif c == "\\":
+                esc = True
+            elif c == '"':
+                in_str = False
+            continue
+        if c == '"':
+            in_str = True
+        elif c == "{":
+            depth += 1
+        elif c == "}":
+            depth -= 1
+            if depth == 0:
+                return j + 1
+    return -1
+
+
+def _coerce_args(value) -> dict:
+    """Normalise a tool ``arguments`` value into a dict.
+
+    Real tool-calling models frequently emit ``arguments`` as a JSON-encoded
+    *string* rather than an object. Decode those; drop anything that is not an
+    object so downstream ``args.get(...)`` never blows up on a str/None.
+    """
+    if isinstance(value, dict):
+        return value
+    if isinstance(value, str):
+        try:
+            parsed = json.loads(value)
+        except json.JSONDecodeError:
+            return {}
+        return parsed if isinstance(parsed, dict) else {}
+    return {}
+
+
+def _normalize_call(obj) -> tuple[str, dict] | None:
+    """Turn a parsed JSON object into ``(name, args)`` if it looks like a call."""
+    if not isinstance(obj, dict):
+        return None
+    # OpenAI shape: {"type": "function", "function": {"name": .., "arguments": ..}}
+    fn = obj.get("function")
+    if isinstance(fn, dict):
+        obj = fn
+    name = obj.get("name") or obj.get("tool")
+    if not isinstance(name, str) or not name:
+        return None
+    args = obj.get("arguments")
+    if args is None:
+        args = obj.get("parameters")
+    if args is None:
+        args = obj.get("args")
+    return (name, _coerce_args(args) if args is not None else {})
+
+
+def _expand(obj) -> list[tuple[str, dict]]:
+    """Expand a parsed JSON value into zero or more calls.
+
+    Handles a single call object, an OpenAI-style ``{"tool_calls": [...]}``
+    envelope, and a bare list of call objects.
+    """
+    out: list[tuple[str, dict]] = []
+    if isinstance(obj, dict) and isinstance(obj.get("tool_calls"), list):
+        obj = obj["tool_calls"]
+    if isinstance(obj, list):
+        for item in obj:
+            call = _normalize_call(item)
+            if call:
+                out.append(call)
+        return out
+    call = _normalize_call(obj)
+    if call:
+        out.append(call)
+    return out
+
+
+def _objects_at(text: str, positions) -> list[tuple[int, int, object]]:
+    """Parse a balanced JSON object at each ``{``; yield (start, end, value)."""
+    found: list[tuple[int, int, object]] = []
+    for i in positions:
+        end = _find_balanced(text, i)
+        if end == -1:
+            continue
+        try:
+            found.append((i, end, json.loads(text[i:end])))
+        except json.JSONDecodeError:
+            continue
+    return found
 
 
 def parse_tool_calls(text: str) -> list[tuple[str, dict]]:
-    """Parse Hermes <tool_call> JSON and legacy TOOL_CALL: lines."""
-    calls: list[tuple[str, dict]] = []
-    for m in _HERMES_TOOL_RE.finditer(text):
+    """Extract tool calls from model output, tolerant of real-world formatting.
+
+    Recognises, in priority order:
+
+    * Hermes/Nous ``<tool_call>{...}</tool_call>`` blocks
+    * Markdown ```` ```json ```` fenced blocks wrapping a call object
+    * Legacy ``TOOL_CALL: name {json}`` lines (name outside the JSON)
+    * A bare JSON call object as a last-resort fallback
+
+    Brace matching is balanced (handles nested ``arguments`` objects), multiple
+    calls are returned in document order, and ``arguments`` supplied as a JSON
+    string is decoded. Anything unparseable is skipped rather than raised.
+    """
+    if not text:
+        return []
+
+    results: list[tuple[int, str, dict]] = []
+    consumed: list[tuple[int, int]] = []
+
+    def _claim(start: int, end: int) -> None:
+        consumed.append((start, end))
+
+    def _overlaps(start: int) -> bool:
+        return any(lo <= start < hi for lo, hi in consumed)
+
+    # 1. Explicit <tool_call> markers (the canonical Hermes format).
+    for m in _HERMES_OPEN_RE.finditer(text):
+        brace = text.find("{", m.end())
+        if brace == -1:
+            continue
+        end = _find_balanced(text, brace)
+        if end == -1:
+            continue
         try:
-            payload = json.loads(m.group(1))
-            calls.append((payload.get("name", ""), payload.get("arguments") or {}))
+            obj = json.loads(text[brace:end])
         except json.JSONDecodeError:
             continue
-    for m in _TOOL_CALL_RE.finditer(text):
-        try:
-            calls.append((m.group(1), json.loads(m.group(2))))
-        except json.JSONDecodeError:
+        for name, args in _expand(obj):
+            results.append((m.start(), name, args))
+        _claim(m.start(), end)
+
+    # 2. Legacy "TOOL_CALL: name {json}" lines (name lives outside the object).
+    for m in _LEGACY_NAME_RE.finditer(text):
+        if _overlaps(m.start()):
             continue
-    return calls
+        # The trailing \s* is consumed by the regex, so the object (if any)
+        # begins immediately at m.end().
+        brace = m.end() if m.end() < len(text) and text[m.end()] == "{" else -1
+        args: dict = {}
+        claim_end = m.end()
+        if brace != -1:
+            end = _find_balanced(text, brace)
+            if end != -1:
+                try:
+                    parsed = json.loads(text[brace:end])
+                    if isinstance(parsed, dict):
+                        args = parsed
+                    claim_end = end
+                except json.JSONDecodeError:
+                    pass
+        results.append((m.start(), m.group(1), args))
+        _claim(m.start(), claim_end)
+
+    # 3. Bare / fenced JSON call objects for any region not already claimed.
+    #    To avoid mistaking ordinary JSON in the brief for a call, a bare object
+    #    must carry an explicit arguments key (or be an OpenAI/list envelope).
+    brace_positions = [
+        i for i, c in enumerate(text) if c == "{" and not _overlaps(i)
+    ]
+    for start, end, obj in _objects_at(text, brace_positions):
+        if _overlaps(start):
+            continue
+        if isinstance(obj, dict) and not (
+            isinstance(obj.get("tool_calls"), list)
+            or isinstance(obj.get("function"), dict)
+            or any(k in obj for k in ("arguments", "parameters", "args"))
+        ):
+            continue
+        calls = _expand(obj)
+        if not calls:
+            continue
+        for name, args in calls:
+            results.append((start, name, args))
+        _claim(start, end)
+
+    results.sort(key=lambda r: r[0])
+    return [(name, args) for _, name, args in results]
 
 
 def research_brief(topic: str, context: str = "n/a") -> tuple[str, dict, tools.ToolContext]:

--- a/solvent/nemotron.py
+++ b/solvent/nemotron.py
@@ -356,16 +356,28 @@ def research_brief(topic: str, context: str = "n/a") -> tuple[str, dict, tools.T
         "After gathering evidence, write the final brief with markdown headings "
         "(no tool calls in the final answer)."
     )
-    user = f"Research topic: {topic}\nClient context: {context}\n\nBegin research."
+    # The transcript carries the running conversation (the model's own plan
+    # text plus each tool observation) so reasoning stays coherent across
+    # rounds; `notes` is the deduplicated evidence handed to the final synth.
+    transcript = f"Research topic: {topic}\nClient context: {context}\n\nBegin research."
 
     for _round in range(tools.MAX_TOOL_ROUNDS):
-        text, usage = complete(system, user)
+        text, usage = complete(system, transcript)
         matches = parse_tool_calls(text)
+
         if not matches:
+            # The model answered without tools: a finished brief ends the loop;
+            # anything else gets one nudge toward synthesis.
             if "# " in text or "## " in text:
                 return text, usage, ctx
-            user = text + "\n\nWrite the final research brief now with markdown headings."
+            transcript += (
+                f"\n\nAssistant: {text}"
+                "\n\nWrite the final research brief now with markdown headings."
+            )
             continue
+
+        # Act: run the requested tools, recording each observation.
+        observations: list[str] = []
         for name, args in matches:
             if ctx.total_calls >= tools.MAX_TOOL_CALLS:
                 ctx.budget_exhausted = True
@@ -374,17 +386,25 @@ def research_brief(topic: str, context: str = "n/a") -> tuple[str, dict, tools.T
                 result = tools.dispatch(
                     name, args, ctx, lambda s, u: complete(s, u)[0], live_search=live_search
                 )
-                notes.append(f"### {name}\n{result}")
             except (ValueError, RuntimeError):
                 continue
-        user = (
-            f"Research notes so far:\n" + "\n\n".join(notes) +
-            "\n\nWrite the final decision-ready research brief for: " + topic
-        )
+            notes.append(f"### {name}\n{result}")
+            observations.append(f"[{name}] {result}")
 
+        # Preserve the model's plan and the new observations for the next round.
+        transcript += f"\n\nAssistant: {text}\n\nTool results:\n" + "\n".join(observations)
+
+        # Once the tool budget is spent there is nothing more to gather — stop
+        # spinning and go straight to synthesis.
+        if ctx.budget_exhausted:
+            break
+
+    # Synthesize: one final pass, tools explicitly closed.
     final_user = (
-        f"Research notes:\n" + "\n\n".join(notes) +
-        f"\n\nProduce the final brief for: {topic}"
+        transcript
+        + "\n\nResearch notes:\n" + "\n\n".join(notes)
+        + f"\n\nNo more tools. Write the final decision-ready research brief for: {topic} "
+        "with markdown headings."
     )
     text, usage = complete(system, final_user)
     return text, usage, ctx

--- a/solvent/stages.py
+++ b/solvent/stages.py
@@ -404,9 +404,16 @@ class StageRunner:
                 if self.t.get_stage(spend_key) and self.t.get_stage(spend_key)["status"] == "completed":
                     continue
                 with self.t.lock():
-                    if not self.guard.approve(amount, vendor, projected_job_margin_cents=job_margin):
-                        self._emit(stage="spend_blocked", job_id=job_id, vendor=vendor, amount=amount, memo=memo)
-                        raise GuardrailError(f"spend to {vendor} of {amount}c rejected by guardrails")
+                    decision = self.guard.evaluate(amount, vendor, projected_job_margin_cents=job_margin)
+                    if not decision.allowed:
+                        self._emit(
+                            stage="spend_blocked", job_id=job_id, vendor=vendor,
+                            amount=amount, memo=memo,
+                            rule=decision.rule, reason=decision.reason,
+                        )
+                        raise GuardrailError(
+                            f"spend to {vendor} of {amount}c rejected by guardrails: {decision.reason}"
+                        )
                     pay = self.stripe.pay_vendor(vendor, amount, memo)
                     self.t.spend(amount, memo, job_id=job_id, vendor=vendor, stripe_ref=pay["id"])
                     self.t.complete_stage(job_id, "spend", spend_key, {"vendor": vendor, "amount": amount})

--- a/solvent/stages.py
+++ b/solvent/stages.py
@@ -12,7 +12,7 @@ from .guardrails import Guardrails, GuardrailError
 from .pricing import quote, PricingPolicy
 from .stripe_client import StripeClient
 from .security import sanitise_job, SOLVENTSecurityError
-from . import service, delivery
+from . import service, delivery, tools
 from .observability import log_event
 
 
@@ -361,6 +361,12 @@ class StageRunner:
                     "deliverable_path": result["deliverable_path"],
                     "tokens": result["tokens"],
                 })
+                _tctx = result.get("tool_ctx")
+                if getattr(_tctx, "budget_exhausted", False):
+                    self._emit(
+                        stage="tool_budget_exhausted", job_id=job_id,
+                        tool_calls=_tctx.total_calls, limit=tools.MAX_TOOL_CALLS,
+                    )
             self._emit(
                 stage="fulfilled",
                 job_id=job_id,
@@ -401,9 +407,15 @@ class StageRunner:
                 if amount <= 0:
                     continue
                 spend_key = f"spend:{job_id}:{vendor}"
-                if self.t.get_stage(spend_key) and self.t.get_stage(spend_key)["status"] == "completed":
+                existing = self.t.get_stage(spend_key)
+                if existing and existing["status"] == "completed":
                     continue
                 with self.t.lock():
+                    # Re-check under the lock: a concurrent advancer may have paid
+                    # this vendor between the fast-path check above and here.
+                    locked = self.t.get_stage(spend_key)
+                    if locked and locked["status"] == "completed":
+                        continue
                     decision = self.guard.evaluate(amount, vendor, projected_job_margin_cents=job_margin)
                     if not decision.allowed:
                         self._emit(

--- a/solvent/stages.py
+++ b/solvent/stages.py
@@ -418,6 +418,9 @@ class StageRunner:
                         continue
                     decision = self.guard.evaluate(amount, vendor, projected_job_margin_cents=job_margin)
                     if not decision.allowed:
+                        self.t.upsert_metrics(
+                            job_id, block_rule=decision.rule, block_reason=decision.reason
+                        )
                         self._emit(
                             stage="spend_blocked", job_id=job_id, vendor=vendor,
                             amount=amount, memo=memo,

--- a/solvent/tools.py
+++ b/solvent/tools.py
@@ -71,6 +71,7 @@ class ToolContext:
     calls: list[dict] = field(default_factory=list)
     web_search_calls: int = 0
     market_data_calls: int = 0
+    budget_exhausted: bool = False  # set when MAX_TOOL_CALLS was hit (truncated)
 
     def record(self, name: str, args: dict, result: str) -> None:
         self.calls.append({"tool": name, "args": args, "result_len": len(result)})
@@ -122,6 +123,31 @@ def _stub_market_data(symbol: str) -> str:
     )
 
 
+def _live_market_data(symbol: str) -> str:
+    """Keyless live quote via Stooq's CSV endpoint; falls back to the stub."""
+    sym = symbol.upper()[:12]
+    try:
+        url = "https://stooq.com/q/l/?" + urllib.parse.urlencode({
+            "s": sym.lower(), "f": "sd2t2ohlcv", "h": "", "e": "csv",
+        })
+        req = urllib.request.Request(url, headers={"User-Agent": "SOLVENT/1.0"})
+        with urllib.request.urlopen(req, timeout=8) as resp:
+            raw = resp.read().decode("utf-8", "replace").strip()
+        # CSV header + one row: Symbol,Date,Time,Open,High,Low,Close,Volume
+        rows = raw.splitlines()
+        if len(rows) >= 2:
+            cols = rows[1].split(",")
+            if len(cols) >= 8 and cols[6] not in ("N/D", ""):
+                _, date, _t, o, hi, lo, close, vol = cols[:8]
+                return (
+                    f"[market_data] {sym}: close ${close} "
+                    f"(O {o} / H {hi} / L {lo}), vol {vol}, as of {date}."
+                )
+    except Exception:
+        pass
+    return _stub_market_data(symbol)
+
+
 def web_search(query: str, *, live: bool = False) -> str:
     if not query or not isinstance(query, str):
         return "empty query"
@@ -131,7 +157,7 @@ def web_search(query: str, *, live: bool = False) -> str:
 def market_data(symbol: str, *, live: bool = False) -> str:
     if not symbol or not isinstance(symbol, str):
         return "empty symbol"
-    return _stub_market_data(symbol)
+    return _live_market_data(symbol) if live else _stub_market_data(symbol)
 
 
 def summarize(text: str, nemotron_fn) -> str:
@@ -146,6 +172,7 @@ def dispatch(name: str, args: dict, ctx: ToolContext, nemotron_fn, live_search: 
     if name not in ALLOWED_TOOLS:
         raise ValueError(f"tool {name!r} not allowlisted")
     if ctx.total_calls >= MAX_TOOL_CALLS:
+        ctx.budget_exhausted = True
         raise RuntimeError(f"max tool calls ({MAX_TOOL_CALLS}) exceeded")
     if name == "web_search":
         result = web_search(args.get("query", ""), live=live_search)

--- a/solvent/treasury.py
+++ b/solvent/treasury.py
@@ -146,9 +146,13 @@ class Treasury:
                         refunded INTEGER DEFAULT 0,
                         tool_calls INTEGER DEFAULT 0,
                         decline_reason TEXT,
+                        block_rule TEXT,
+                        block_reason TEXT,
                         ts REAL NOT NULL
                     )
                 """)
+                self._ensure_column(conn, "job_metrics", "block_rule", "TEXT")
+                self._ensure_column(conn, "job_metrics", "block_reason", "TEXT")
                 conn.execute("""
                     CREATE TABLE IF NOT EXISTS stripe_checkout (
                         job_id TEXT PRIMARY KEY,
@@ -554,6 +558,7 @@ class Treasury:
                             "est_cost_cents", "actual_cost_cents", "est_margin_pct",
                             "actual_margin_pct", "margin_drift_cents", "fulfillment_seconds",
                             "refunded", "tool_calls", "decline_reason",
+                            "block_rule", "block_reason",
                         ):
                             if col in kwargs:
                                 fields.append(f"{col} = ?")
@@ -570,6 +575,7 @@ class Treasury:
                             "est_cost_cents", "actual_cost_cents", "est_margin_pct",
                             "actual_margin_pct", "margin_drift_cents", "fulfillment_seconds",
                             "refunded", "tool_calls", "decline_reason",
+                            "block_rule", "block_reason",
                         ):
                             if col in kwargs:
                                 cols.append(col)

--- a/tests/test_chat_tools.py
+++ b/tests/test_chat_tools.py
@@ -48,6 +48,34 @@ class TestChatTools(unittest.TestCase):
         self.assertIn("healthy", reply.lower())
 
     @patch.object(nemotron, "complete")
+    def test_per_turn_tool_budget(self, mock_complete):
+        """A single reply with many tool calls is capped at the per-turn budget."""
+        import solvent.chat as chatmod
+        from solvent.hermes_tools import ToolRegistry
+
+        many = " ".join(
+            '<tool_call>{"name": "treasury_status", "arguments": {}}</tool_call>'
+            for _ in range(25)
+        )
+        mock_complete.side_effect = [(many, {}), ("All set.", {})]
+
+        calls = {"n": 0}
+        orig = ToolRegistry.dispatch
+
+        def counting(self, name, args):
+            calls["n"] += 1
+            return orig(self, name, args)
+
+        with patch.object(ToolRegistry, "dispatch", counting), \
+             patch.object(chatmod.tools, "MAX_TOOL_CALLS", 5):
+            reply = handle_message(
+                self.session["id"], "spam tools", agent=self.agent, memory=self.memory
+            )
+
+        self.assertLessEqual(calls["n"], 5)
+        self.assertIn("set", reply.lower())
+
+    @patch.object(nemotron, "complete")
     def test_submit_brief_via_tool(self, mock_complete):
         mock_complete.side_effect = [
             (

--- a/tests/test_guardrails.py
+++ b/tests/test_guardrails.py
@@ -1,7 +1,7 @@
 import unittest
 import time
 from unittest.mock import MagicMock
-from solvent.guardrails import Guardrails, SpendPolicy, GuardrailError
+from solvent.guardrails import Guardrails, SpendPolicy, GuardrailError, Decision
 from solvent.treasury import LedgerEntry
 
 
@@ -119,6 +119,66 @@ class TestGuardrails(unittest.TestCase):
 
         # Case 4: Projected margin is not provided (None) -> approved
         self.assertTrue(self.guard.approve(500, "nvidia-nemotron", projected_job_margin_cents=None))
+
+
+class TestGuardrailDecision(unittest.TestCase):
+    """The structured Decision API used for auditable spend screening."""
+
+    def setUp(self) -> None:
+        self.t = MagicMock()
+        self.t.balance_cents.return_value = 10000
+        self.t.entries = []
+        self.guard = Guardrails(self.t)
+
+    def test_approved_decision_carries_context(self) -> None:
+        d = self.guard.evaluate(500, "nvidia-nemotron", projected_job_margin_cents=100)
+        self.assertIsInstance(d, Decision)
+        self.assertTrue(d.allowed)
+        self.assertIsNone(d.rule)
+        self.assertEqual(d.reason, "approved")
+        self.assertEqual(d.amount_cents, 500)
+        self.assertEqual(d.vendor, "nvidia-nemotron")
+        self.assertEqual(d.balance_cents, 10000)
+
+    def test_denied_decision_names_the_rule(self) -> None:
+        cases = [
+            (dict(amount_cents=100, vendor="rogue-vendor"), "vendor_allowlist"),
+            (dict(amount_cents=9999, vendor="nvidia-nemotron"), "max_txn_cap"),
+        ]
+        for kwargs, rule in cases:
+            d = self.guard.evaluate(**kwargs)
+            self.assertFalse(d.allowed)
+            self.assertEqual(d.rule, rule)
+            self.assertTrue(d.reason)
+
+    def test_reserve_rule_id(self) -> None:
+        self.t.balance_cents.return_value = 2500
+        d = self.guard.evaluate(501, "nvidia-nemotron")
+        self.assertFalse(d.allowed)
+        self.assertEqual(d.rule, "min_reserve")
+
+    def test_roi_rule_id(self) -> None:
+        d = self.guard.evaluate(500, "nvidia-nemotron", projected_job_margin_cents=-1)
+        self.assertFalse(d.allowed)
+        self.assertEqual(d.rule, "roi")
+
+    def test_first_violation_wins_priority(self) -> None:
+        # Both an unlisted vendor AND an over-cap amount: allowlist is checked first.
+        d = self.guard.evaluate(9999, "rogue-vendor")
+        self.assertEqual(d.rule, "vendor_allowlist")
+
+    def test_as_dict_is_serialisable(self) -> None:
+        import json
+        d = self.guard.evaluate(100, "rogue-vendor")
+        payload = json.dumps(d.as_dict())
+        self.assertIn("vendor_allowlist", payload)
+
+    def test_evaluate_and_approve_agree(self) -> None:
+        for amount, vendor in [(500, "nvidia-nemotron"), (9999, "nvidia-nemotron"), (100, "nope")]:
+            self.assertEqual(
+                self.guard.evaluate(amount, vendor).allowed,
+                self.guard.approve(amount, vendor),
+            )
 
 
 if __name__ == "__main__":

--- a/tests/test_metrics_block.py
+++ b/tests/test_metrics_block.py
@@ -1,0 +1,52 @@
+"""Tests for guardrail block reason persistence in job_metrics (+ migration)."""
+
+import sqlite3
+import tempfile
+import unittest
+from pathlib import Path
+
+from solvent.treasury import Treasury
+
+
+class TestBlockMetrics(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.db = Path(self.tmp.name) / "t.db"
+
+    def tearDown(self):
+        self.tmp.cleanup()
+
+    def test_block_reason_round_trips(self):
+        t = Treasury(path=self.db)
+        t.upsert_metrics("J1", est_cost_cents=100)
+        t.upsert_metrics("J1", block_rule="min_reserve", block_reason="would breach minimum cash reserve")
+        m = t.get_metrics("J1")
+        self.assertEqual(m["block_rule"], "min_reserve")
+        self.assertEqual(m["block_reason"], "would breach minimum cash reserve")
+        # the earlier metric is preserved by the upsert
+        self.assertEqual(m["est_cost_cents"], 100)
+
+    def test_migration_adds_columns_to_legacy_db(self):
+        # Hand-build a legacy job_metrics table without the block_* columns.
+        conn = sqlite3.connect(self.db)
+        conn.execute(
+            "CREATE TABLE job_metrics (job_id TEXT PRIMARY KEY, "
+            "est_cost_cents INTEGER, ts REAL NOT NULL)"
+        )
+        conn.execute("INSERT INTO job_metrics (job_id, ts) VALUES ('OLD', 0)")
+        conn.commit()
+        conn.close()
+
+        # Opening the Treasury should migrate the schema in place.
+        t = Treasury(path=self.db)
+        cols = {r[1] for r in sqlite3.connect(self.db).execute("PRAGMA table_info(job_metrics)")}
+        self.assertIn("block_rule", cols)
+        self.assertIn("block_reason", cols)
+
+        # And the new columns are usable on the pre-existing row.
+        t.upsert_metrics("OLD", block_rule="vendor_allowlist", block_reason="nope")
+        self.assertEqual(t.get_metrics("OLD")["block_rule"], "vendor_allowlist")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_nemotron_parse.py
+++ b/tests/test_nemotron_parse.py
@@ -73,6 +73,10 @@ class TestNemotronParse(unittest.TestCase):
             [("web_search", {"query": "a"}), ("summarize", {"text": "t"})],
         )
 
+    def test_fenced_block_as_whole_message(self):
+        text = '```json\n{"name": "market_data", "arguments": {"symbol": "NVDA"}}\n```'
+        self.assertEqual(parse_tool_calls(text), [("market_data", {"symbol": "NVDA"})])
+
     # --- things that must NOT be mistaken for calls ------------------------
     def test_prose_without_calls(self):
         self.assertEqual(parse_tool_calls("# Brief\n\nSome prose. {not a call}"), [])
@@ -80,6 +84,27 @@ class TestNemotronParse(unittest.TestCase):
     def test_bare_data_object_is_not_a_call(self):
         """A JSON object lacking a name/arguments shape is not a tool call."""
         self.assertEqual(parse_tool_calls('Data: {"price": 100, "vol": 5}'), [])
+
+    def test_json_embedded_in_brief_is_not_a_call(self):
+        """Regression: a brief that *contains* call-shaped JSON must not parse.
+
+        The bare-JSON fallback only fires when the whole message is one JSON
+        object; JSON illustrated inside prose stays prose.
+        """
+        brief = (
+            "## Example config\n"
+            'Use this snippet: {"name": "deploy", "arguments": {"x": 1}} in your file.\n'
+            "## Recommendation\nShip it."
+        )
+        self.assertEqual(parse_tool_calls(brief), [])
+
+    def test_explicit_marker_suppresses_bare_fallback(self):
+        """A real <tool_call> plus stray JSON elsewhere yields only the real call."""
+        text = (
+            '<tool_call>{"name": "web_search", "arguments": {"query": "ai"}}</tool_call>\n'
+            'For reference: {"name": "noise", "arguments": {"y": 2}}'
+        )
+        self.assertEqual(parse_tool_calls(text), [("web_search", {"query": "ai"})])
 
     def test_empty_and_none(self):
         self.assertEqual(parse_tool_calls(""), [])

--- a/tests/test_nemotron_parse.py
+++ b/tests/test_nemotron_parse.py
@@ -1,15 +1,135 @@
 import unittest
+from unittest.mock import patch
 
+from solvent import nemotron
 from solvent.nemotron import parse_tool_calls
 
 
 class TestNemotronParse(unittest.TestCase):
+    # --- formats the original parser already handled -----------------------
     def test_hermes_format(self):
         text = '<tool_call>{"name": "web_search", "arguments": {"query": "ai"}}</tool_call>'
-        calls = parse_tool_calls(text)
-        self.assertEqual(calls, [("web_search", {"query": "ai"})])
+        self.assertEqual(parse_tool_calls(text), [("web_search", {"query": "ai"})])
 
     def test_legacy_format(self):
         text = 'TOOL_CALL: market_data {"symbol": "NVDA"}'
-        calls = parse_tool_calls(text)
-        self.assertEqual(calls, [("market_data", {"symbol": "NVDA"})])
+        self.assertEqual(parse_tool_calls(text), [("market_data", {"symbol": "NVDA"})])
+
+    # --- robustness gaps the rewrite closes --------------------------------
+    def test_legacy_nested_arguments(self):
+        """Nested objects must not be truncated by naive non-greedy matching."""
+        text = 'TOOL_CALL: submit_brief {"topic": "x", "meta": {"a": 1}}'
+        self.assertEqual(
+            parse_tool_calls(text),
+            [("submit_brief", {"topic": "x", "meta": {"a": 1}})],
+        )
+
+    def test_hermes_nested_arguments(self):
+        text = '<tool_call>{"name": "submit_brief", "arguments": {"topic": "x", "opts": {"deep": true}}}</tool_call>'
+        self.assertEqual(
+            parse_tool_calls(text),
+            [("submit_brief", {"topic": "x", "opts": {"deep": True}})],
+        )
+
+    def test_fenced_json_block(self):
+        text = '```json\n{"name": "web_search", "arguments": {"query": "ai"}}\n```'
+        self.assertEqual(parse_tool_calls(text), [("web_search", {"query": "ai"})])
+
+    def test_openai_parameters_key(self):
+        text = '{"name": "web_search", "parameters": {"query": "ai"}}'
+        self.assertEqual(parse_tool_calls(text), [("web_search", {"query": "ai"})])
+
+    def test_openai_function_envelope(self):
+        text = '{"type": "function", "function": {"name": "market_data", "arguments": "{\\"symbol\\": \\"NVDA\\"}"}}'
+        self.assertEqual(parse_tool_calls(text), [("market_data", {"symbol": "NVDA"})])
+
+    def test_arguments_as_json_string(self):
+        """Models often emit arguments as a JSON-encoded string, not an object."""
+        text = '<tool_call>{"name": "web_search", "arguments": "{\\"query\\": \\"ai\\"}"}</tool_call>'
+        got = parse_tool_calls(text)
+        self.assertEqual(got, [("web_search", {"query": "ai"})])
+        # critical: args must be a dict so downstream args.get(...) is safe
+        self.assertIsInstance(got[0][1], dict)
+
+    def test_multiple_calls_in_order(self):
+        text = (
+            '<tool_call>{"name": "web_search", "arguments": {"query": "a"}}</tool_call>'
+            " then "
+            '<tool_call>{"name": "market_data", "arguments": {"symbol": "NVDA"}}</tool_call>'
+        )
+        self.assertEqual(
+            parse_tool_calls(text),
+            [("web_search", {"query": "a"}), ("market_data", {"symbol": "NVDA"})],
+        )
+
+    def test_tool_calls_envelope(self):
+        text = (
+            '{"tool_calls": ['
+            '{"name": "web_search", "arguments": {"query": "a"}},'
+            '{"name": "summarize", "arguments": {"text": "t"}}]}'
+        )
+        self.assertEqual(
+            parse_tool_calls(text),
+            [("web_search", {"query": "a"}), ("summarize", {"text": "t"})],
+        )
+
+    # --- things that must NOT be mistaken for calls ------------------------
+    def test_prose_without_calls(self):
+        self.assertEqual(parse_tool_calls("# Brief\n\nSome prose. {not a call}"), [])
+
+    def test_bare_data_object_is_not_a_call(self):
+        """A JSON object lacking a name/arguments shape is not a tool call."""
+        self.assertEqual(parse_tool_calls('Data: {"price": 100, "vol": 5}'), [])
+
+    def test_empty_and_none(self):
+        self.assertEqual(parse_tool_calls(""), [])
+        self.assertEqual(parse_tool_calls("no json here at all"), [])
+
+    def test_malformed_json_is_skipped(self):
+        self.assertEqual(parse_tool_calls('<tool_call>{"name": "x", arguments:}</tool_call>'), [])
+
+
+class TestLiveRetry(unittest.TestCase):
+    def test_retries_transient_then_succeeds(self):
+        import urllib.error
+
+        calls = {"n": 0}
+
+        def flaky(system, user):
+            calls["n"] += 1
+            if calls["n"] < 3:
+                raise urllib.error.URLError("connection reset")
+            return {
+                "choices": [{"message": {"content": "ok"}}],
+                "usage": {"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2},
+            }
+
+        with patch.object(nemotron, "_live_request", side_effect=flaky), \
+             patch.object(nemotron, "MAX_RETRIES", 3), \
+             patch.object(nemotron.time, "sleep", lambda *_: None):
+            text, usage = nemotron._live_complete("sys", "usr")
+
+        self.assertEqual(text, "ok")
+        self.assertEqual(calls["n"], 3)
+        self.assertFalse(usage["estimated"])
+
+    def test_permanent_error_not_retried(self):
+        import urllib.error
+
+        calls = {"n": 0}
+
+        def bad_key(system, user):
+            calls["n"] += 1
+            raise urllib.error.HTTPError(nemotron.ENDPOINT, 401, "Unauthorized", {}, None)
+
+        with patch.object(nemotron, "_live_request", side_effect=bad_key), \
+             patch.object(nemotron, "MAX_RETRIES", 3), \
+             patch.object(nemotron.time, "sleep", lambda *_: None):
+            with self.assertRaises(urllib.error.HTTPError):
+                nemotron._live_complete("sys", "usr")
+
+        self.assertEqual(calls["n"], 1)  # not retried
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_research_brief.py
+++ b/tests/test_research_brief.py
@@ -1,0 +1,53 @@
+"""Tests for the research_brief plan -> act -> synthesize loop."""
+
+import unittest
+from unittest.mock import patch
+
+from solvent import nemotron
+
+
+def _tool(name="web_search", query="q"):
+    return f'<tool_call>{{"name":"{name}","arguments":{{"query":"{query}"}}}}</tool_call>'
+
+
+class TestResearchBrief(unittest.TestCase):
+    def setUp(self):
+        self._prev_offline = nemotron._force_offline
+        self.addCleanup(setattr, nemotron, "_force_offline", self._prev_offline)
+
+    def test_offline_stub_returns_on_first_round(self):
+        """No mocking: the deterministic stub yields a brief immediately."""
+        nemotron.configure(model="offline")
+        text, usage, ctx = nemotron.research_brief("NVIDIA datacenter demand")
+        self.assertIn("##", text)
+        self.assertEqual(ctx.total_calls, 0)
+
+    @patch.object(nemotron, "complete")
+    def test_runs_tool_then_synthesizes(self, mock_complete):
+        mock_complete.side_effect = [
+            (_tool(), {"total_tokens": 5}),
+            ("## Brief\n\nFindings.", {"total_tokens": 10}),
+        ]
+        text, usage, ctx = nemotron.research_brief("AI chips")
+        self.assertIn("## Brief", text)
+        self.assertEqual(ctx.web_search_calls, 1)
+        self.assertFalse(ctx.budget_exhausted)
+        self.assertEqual(mock_complete.call_count, 2)
+
+    @patch.object(nemotron, "complete")
+    def test_stops_when_budget_exhausted(self, mock_complete):
+        three = " ".join(_tool(query=f"q{i}") for i in range(3))
+        mock_complete.side_effect = [
+            (three, {"total_tokens": 1}),
+            ("## Final\n\nDone.", {"total_tokens": 1}),
+        ]
+        with patch.object(nemotron.tools, "MAX_TOOL_CALLS", 2):
+            text, usage, ctx = nemotron.research_brief("topic")
+        self.assertTrue(ctx.budget_exhausted)
+        self.assertEqual(ctx.total_calls, 2)        # capped, not 3
+        self.assertIn("Final", text)
+        self.assertEqual(mock_complete.call_count, 2)  # one gather round + synth
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -21,11 +21,28 @@ class TestTools(unittest.TestCase):
         ctx = ToolContext()
         for i in range(MAX_TOOL_CALLS):
             dispatch("web_search", {"query": f"q{i}"}, ctx, lambda s, u: ("", {}))
+        self.assertFalse(ctx.budget_exhausted)
         with self.assertRaises(RuntimeError):
             dispatch("web_search", {"query": "one more"}, ctx, lambda s, u: ("", {}))
+        # hitting the cap must be observable, not silent
+        self.assertTrue(ctx.budget_exhausted)
 
     def test_allowed_set(self):
         self.assertIn("market_data", ALLOWED_TOOLS)
+
+    def test_market_data_offline_is_stub(self):
+        from solvent.tools import market_data
+        out = market_data("NVDA", live=False)
+        self.assertIn("offline stub", out)
+
+    def test_market_data_live_falls_back_to_stub_on_error(self):
+        """live=True must degrade gracefully to the stub if the fetch fails."""
+        import solvent.tools as t
+        from unittest.mock import patch
+        with patch.object(t.urllib.request, "urlopen", side_effect=OSError("no net")):
+            out = t.market_data("NVDA", live=True)
+        self.assertIn("NVDA", out)
+        self.assertIn("offline stub", out)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## What & why

Hardens SOLVENT's agent loop, tool-calling, and spend guardrails, adapting patterns from established open-source function-calling implementations (Nous Hermes format / vLLM `hermes_tool_parser`) and policy engines (OPA/Cedar). No third-party code copied — patterns reimplemented in stdlib.

## Changes (by commit)

**1. Robust tool-call parsing + retrying model calls** (`nemotron.py`)
- Rewrote `parse_tool_calls` around **balanced-brace JSON scanning** instead of a non-greedy regex that **silently dropped any call with nested `arguments`** (a real bug). Accepts Hermes `<tool_call>` blocks, ` ```json ` fences, OpenAI `{"function":...}` / `"parameters"` shapes, `{"tool_calls":[...]}` envelopes, multiple calls in order, and `arguments` as a JSON-encoded string (coerced to dict).
- Bounded exponential-backoff **retry** on the live Nemotron call for transient failures (429/5xx/network); permanent errors still raise.

**2. Structured, auditable guardrail decisions** (`guardrails.py`, `stages.py`, `dashboard.py`)
- OPA/Cedar-style `Decision` (allowed, rule id, reason, context). `check_spend`/`approve` delegate to a single-snapshot `evaluate()` — backward compatible. Blocked spends now record **why** on the audit event and dashboard.

**3. Parser false-positive fix** (`nemotron.py`) — reviewer-found regression
- The bare-JSON fallback now fires **only when the whole message is a single JSON object**, so JSON embedded in a brief/chat reply is never mistaken for a call. Aligned `research_brief`'s system prompt with the parser's preferred Hermes format.

**4. Agent-loop hardening** (`stages.py`, `chat.py`, `tools.py`)
- **TOCTOU fix**: re-check spend idempotency inside the treasury lock so concurrent advancers can't double-pay a vendor.
- **Per-turn tool-call budget** in the chat loop (cost/abuse guard on live search).
- `market_data(live=True)` was a silent no-op returning stub data — implemented a keyless live quote (Stooq CSV) that degrades to the stub on error.
- **Observability**: `ToolContext.budget_exhausted` + a `tool_budget_exhausted` event instead of a silent truncation.

**5. Persist guardrail block rule/reason to `job_metrics`** (`treasury.py`, `stages.py`)
- Added `block_rule`/`block_reason` columns (new DBs + in-place `_ensure_column` migration for existing ones) so blocked-spend reasons are queryable for aggregate audit, not just on the event log.

**6. Clearer plan→act→synthesize `research_brief` loop** (`nemotron.py`)
- Carries a running transcript (the model's plan + each observation) across rounds, stops spinning once the tool budget is exhausted, and makes the final synthesis explicit. Offline-stub path unchanged (returns on round one).

## Verification
- `pytest tests/` → **250 passed, 6 skipped** (was 218 on `main`; +32 new tests).
- Smoke-tested the full earn→fulfil→spend→book loop end-to-end on the offline stub (all stages: quote → invoice → paid → fulfilled → delivered → spend → booked).

🤖 Generated with [Claude Code](https://claude.com/claude-code)