### PR TITLE
Financial reporting command (income statement, unit economics, runway) + fix subcommand routing

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,7 +194,15 @@ See [docs/PRODUCTION.md](docs/PRODUCTION.md) for Stripe webhook setup, SMTP deli
 python3 -m solvent reconcile --since 7d   # Stripe ↔ ledger drift check
 python3 -m solvent tune                   # propose pricing improvements (dry-run)
 python3 -m solvent tune --apply             # apply after 5+ completed jobs
+python3 -m solvent finance                # income statement, unit economics, runway
+python3 -m solvent finance --json         # machine-readable report
+python3 -m solvent finance --reserve 50   # runway to a $50 cash-reserve floor
 ```
+
+`finance` (alias `report`) turns the treasury ledger into the numbers a
+business steers by: revenue/cost/net-margin, average profit per job, and a cash
+**runway** — days of burn remaining, or `cash-flow positive` once the agent
+funds itself.
 
 ---
 

--- a/solvent/__main__.py
+++ b/solvent/__main__.py
@@ -52,6 +52,10 @@ def main():
         s = SolventStages(treasury=t, guard=Guardrails(t), stripe=StripeClient())
         result = s.retry_job(job_id)
         import json; print(json.dumps(result, indent=2, default=str))
+    elif len(sys.argv) > 1 and sys.argv[1] in ("finance", "report"):
+        sys.argv.pop(1)
+        from .finance import main as finance_main
+        finance_main()
     elif len(sys.argv) > 1 and sys.argv[1] == "webhooks":
         from .webhook_log import WebhookLog
         import json
@@ -66,10 +70,9 @@ def main():
             for row in wl.list_failed():
                 print(f"  {row['event_id'][:16]} {row['event_type']} err={row['error'][:60]}")
     else:
-        from run_demo import main as demo_main
+        # No subcommand: fall through to the demo / interactive CLI.
+        from .cli import main as demo_main
         demo_main()
-
-from .cli import main
 
 
 if __name__ == "__main__":

--- a/solvent/finance.py
+++ b/solvent/finance.py
@@ -1,0 +1,264 @@
+"""
+finance.py — financial intelligence for a self-funding agent.
+
+SOLVENT books every dollar to the treasury ledger; this module turns that
+ledger into the numbers a business actually steers by:
+
+  * income statement   — revenue, operating cost, net profit, margin
+  * unit economics      — what one job earns, costs, and nets on average
+  * runway              — cash on hand vs. burn rate → days of runway, or
+                          "cash-flow positive" when the agent funds itself
+  * a balance sparkline — the treasury's trajectory at a glance
+
+Everything is computed from ``LedgerEntry`` records, so the functions are
+pure and trivially testable without a database. Exposed on the CLI as
+``python -m solvent finance`` (alias ``report``).
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+import time
+from typing import Iterable, Optional
+
+from .treasury import LedgerEntry, Treasury, fmt
+
+# Below this much elapsed history a daily burn/gain rate is statistical noise,
+# so we decline to project a runway rather than quote a meaningless number.
+MIN_SPAN_DAYS = 1.0 / 24.0  # one hour
+
+_SPARK_TICKS = "▁▂▃▄▅▆▇█"
+
+
+def _signed(e: LedgerEntry) -> int:
+    return e.amount_cents if e.kind in ("revenue", "capital") else -e.amount_cents
+
+
+def income_statement(entries: Iterable[LedgerEntry]) -> dict:
+    """Revenue, operating cost, net profit and margin, plus a vendor breakdown."""
+    entries = list(entries)
+    revenue = sum(e.amount_cents for e in entries if e.kind == "revenue")
+    expense = sum(e.amount_cents for e in entries if e.kind == "expense")
+    capital = sum(e.amount_cents for e in entries if e.kind == "capital")
+    net = revenue - expense
+
+    by_vendor: dict[str, int] = {}
+    for e in entries:
+        if e.kind == "expense":
+            by_vendor[e.vendor or "unattributed"] = (
+                by_vendor.get(e.vendor or "unattributed", 0) + e.amount_cents
+            )
+
+    return {
+        "revenue_cents": revenue,
+        "operating_cost_cents": expense,
+        "net_profit_cents": net,
+        "net_margin_pct": round(100 * net / revenue, 1) if revenue else 0.0,
+        "seed_capital_cents": capital,
+        "balance_cents": sum(_signed(e) for e in entries),
+        "expense_by_vendor": dict(
+            sorted(by_vendor.items(), key=lambda kv: kv[1], reverse=True)
+        ),
+    }
+
+
+def unit_economics(entries: Iterable[LedgerEntry]) -> dict:
+    """Per-job averages: revenue, cost, profit and contribution margin.
+
+    Robust regardless of wall-clock span — meaningful even after a 30-second
+    demo run, unlike a time-based burn rate.
+    """
+    jobs: dict[str, dict[str, int]] = {}
+    for e in entries:
+        if e.kind in ("revenue", "expense") and e.job_id:
+            agg = jobs.setdefault(e.job_id, {"rev": 0, "exp": 0})
+            agg["rev" if e.kind == "revenue" else "exp"] += e.amount_cents
+
+    completed = [v for v in jobs.values() if v["rev"] > 0]
+    n = len(completed)
+    if not n:
+        return {
+            "completed_jobs": 0,
+            "avg_revenue_cents": 0,
+            "avg_cost_cents": 0,
+            "avg_profit_cents": 0,
+            "contribution_margin_pct": 0.0,
+        }
+
+    avg_rev = sum(v["rev"] for v in completed) // n
+    avg_exp = sum(v["exp"] for v in completed) // n
+    avg_profit = avg_rev - avg_exp
+    return {
+        "completed_jobs": n,
+        "avg_revenue_cents": avg_rev,
+        "avg_cost_cents": avg_exp,
+        "avg_profit_cents": avg_profit,
+        "contribution_margin_pct": round(100 * avg_profit / avg_rev, 1) if avg_rev else 0.0,
+    }
+
+
+def runway(
+    entries: Iterable[LedgerEntry],
+    *,
+    reserve_cents: int = 0,
+    now: Optional[float] = None,
+) -> dict:
+    """Cash runway from the operating burn/gain rate.
+
+    Returns the current balance, the average daily net operating cash flow,
+    and — when the agent is net-burning — how many days until cash hits the
+    reserve floor. A net-positive trend reports ``cashflow_positive``.
+    """
+    entries = list(entries)
+    balance = sum(_signed(e) for e in entries)
+    op = [e for e in entries if e.kind in ("revenue", "expense")]
+
+    base = {
+        "balance_cents": balance,
+        "reserve_cents": reserve_cents,
+        "spendable_cents": balance - reserve_cents,
+        "daily_net_cents": None,
+        "runway_days": None,
+        "cashflow_positive": None,
+        "status": "idle",
+    }
+    if not op:
+        return base
+
+    times = [e.ts for e in op]
+    span_days = (max(times) - min(times)) / 86_400.0
+    net_op = sum(_signed(e) for e in op)
+    base["cashflow_positive"] = net_op >= 0
+
+    if span_days < MIN_SPAN_DAYS:
+        base["status"] = "insufficient_history"
+        return base
+
+    daily_net = net_op / span_days
+    base["daily_net_cents"] = round(daily_net)
+
+    if daily_net >= 0:
+        base["status"] = "cashflow_positive"
+        base["runway_days"] = None  # self-funding: not burning down
+    else:
+        base["status"] = "burning"
+        base["runway_days"] = round(max(0.0, (balance - reserve_cents) / -daily_net), 1)
+    return base
+
+
+def balance_series(entries: Iterable[LedgerEntry], buckets: int = 40) -> list[int]:
+    """Running balance over time, down-sampled to at most ``buckets`` points."""
+    ordered = sorted(entries, key=lambda e: e.ts)
+    running = 0
+    series: list[int] = []
+    for e in ordered:
+        running += _signed(e)
+        series.append(running)
+    if len(series) <= buckets:
+        return series
+    step = len(series) / buckets
+    return [series[min(len(series) - 1, int(i * step))] for i in range(buckets)]
+
+
+def sparkline(values: list[int]) -> str:
+    """Render integers as a compact unicode sparkline."""
+    if not values:
+        return ""
+    lo, hi = min(values), max(values)
+    if hi == lo:
+        return _SPARK_TICKS[0] * len(values)
+    span = hi - lo
+    return "".join(
+        _SPARK_TICKS[min(len(_SPARK_TICKS) - 1, (v - lo) * (len(_SPARK_TICKS) - 1) // span)]
+        for v in values
+    )
+
+
+def build_report(entries: Iterable[LedgerEntry], *, reserve_cents: int = 0) -> dict:
+    """Assemble the full financial picture as a JSON-serialisable dict."""
+    entries = list(entries)
+    return {
+        "income_statement": income_statement(entries),
+        "unit_economics": unit_economics(entries),
+        "runway": runway(entries, reserve_cents=reserve_cents),
+        "balance_sparkline": sparkline(balance_series(entries)),
+    }
+
+
+def format_report(report: dict) -> str:
+    """Human-readable text rendering of :func:`build_report`."""
+    inc = report["income_statement"]
+    ue = report["unit_economics"]
+    rw = report["runway"]
+    lines = [
+        "SOLVENT — Financial Report",
+        "=" * 48,
+        "",
+        "Income statement",
+        f"  Revenue            {fmt(inc['revenue_cents'])}",
+        f"  Operating cost     {fmt(inc['operating_cost_cents'])}",
+        f"  Net profit         {fmt(inc['net_profit_cents'])}  ({inc['net_margin_pct']}% margin)",
+        f"  Cash balance       {fmt(inc['balance_cents'])}  (seed {fmt(inc['seed_capital_cents'])})",
+    ]
+    if inc["expense_by_vendor"]:
+        lines.append("  Operating cost by vendor:")
+        for vendor, amt in inc["expense_by_vendor"].items():
+            lines.append(f"    - {vendor:<22} {fmt(amt)}")
+
+    lines += [
+        "",
+        "Unit economics (per completed job)",
+        f"  Completed jobs     {ue['completed_jobs']}",
+        f"  Avg revenue        {fmt(ue['avg_revenue_cents'])}",
+        f"  Avg cost           {fmt(ue['avg_cost_cents'])}",
+        f"  Avg profit         {fmt(ue['avg_profit_cents'])}  ({ue['contribution_margin_pct']}% contribution)",
+        "",
+        "Runway",
+    ]
+    if rw["status"] == "idle":
+        lines.append("  No operating activity yet.")
+    elif rw["status"] == "insufficient_history":
+        lines.append(
+            f"  Balance {fmt(rw['balance_cents'])} — too little time history to project a daily rate."
+        )
+    elif rw["status"] == "cashflow_positive":
+        lines.append(
+            f"  Cash-flow positive: +{fmt(rw['daily_net_cents'])}/day. "
+            "The agent funds itself — no runway burndown."
+        )
+    else:  # burning
+        lines.append(
+            f"  Burning {fmt(-rw['daily_net_cents'])}/day → "
+            f"{rw['runway_days']} days of runway "
+            f"(to {fmt(rw['reserve_cents'])} reserve)."
+        )
+
+    spark = report.get("balance_sparkline")
+    if spark:
+        lines += ["", f"Balance trajectory  {spark}"]
+    return "\n".join(lines)
+
+
+def main() -> None:
+    """CLI: ``python -m solvent finance [--json] [--reserve USD]``."""
+    args = sys.argv[1:]
+    as_json = "--json" in args
+    reserve_cents = 0
+    if "--reserve" in args:
+        try:
+            reserve_cents = int(float(args[args.index("--reserve") + 1]) * 100)
+        except (ValueError, IndexError):
+            print("Usage: python -m solvent finance [--json] [--reserve <usd>]")
+            sys.exit(1)
+
+    entries = Treasury().entries
+    report = build_report(entries, reserve_cents=reserve_cents)
+    if as_json:
+        print(json.dumps(report, indent=2))
+    else:
+        print(format_report(report))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_cli_routing.py
+++ b/tests/test_cli_routing.py
@@ -1,0 +1,44 @@
+"""The __main__ subcommand router must dispatch, not fall through to the demo.
+
+Regression: a stray `from .cli import main` used to shadow the router so every
+documented subcommand (serve/worker/doctor/...) silently ran the demo CLI.
+"""
+
+import unittest
+from unittest.mock import patch
+
+import solvent.__main__ as entry
+
+
+class TestCliRouting(unittest.TestCase):
+    def _routes_to(self, argv, target_module, target_attr="main"):
+        with patch.object(entry.sys, "argv", argv), \
+             patch(f"solvent.{target_module}.{target_attr}") as mock_target, \
+             patch("solvent.cli.main") as mock_demo:
+            entry.main()
+        return mock_target, mock_demo
+
+    def test_finance_routes_to_finance(self):
+        target, demo = self._routes_to(["solvent", "finance"], "finance")
+        target.assert_called_once()
+        demo.assert_not_called()
+
+    def test_report_alias_routes_to_finance(self):
+        target, demo = self._routes_to(["solvent", "report"], "finance")
+        target.assert_called_once()
+        demo.assert_not_called()
+
+    def test_doctor_routes_to_doctor(self):
+        target, demo = self._routes_to(["solvent", "doctor"], "doctor")
+        target.assert_called_once()
+        demo.assert_not_called()
+
+    def test_no_subcommand_runs_demo(self):
+        with patch.object(entry.sys, "argv", ["solvent"]), \
+             patch("solvent.cli.main") as mock_demo:
+            entry.main()
+        mock_demo.assert_called_once()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_finance.py
+++ b/tests/test_finance.py
@@ -1,0 +1,133 @@
+"""Tests for the finance analytics module."""
+
+import unittest
+
+from solvent.finance import (
+    income_statement,
+    unit_economics,
+    runway,
+    balance_series,
+    sparkline,
+    build_report,
+    format_report,
+)
+from solvent.treasury import LedgerEntry
+
+DAY = 86_400.0
+
+
+def _e(kind, cents, *, job_id=None, vendor=None, ts=0.0):
+    return LedgerEntry(kind=kind, amount_cents=cents, memo="x", job_id=job_id, vendor=vendor, ts=ts)
+
+
+class TestIncomeStatement(unittest.TestCase):
+    def test_totals_and_margin(self):
+        entries = [
+            _e("capital", 10000),
+            _e("revenue", 5000, job_id="J1"),
+            _e("expense", 1000, job_id="J1", vendor="nvidia-nemotron"),
+            _e("expense", 500, job_id="J1", vendor="pdf-render-saas"),
+        ]
+        inc = income_statement(entries)
+        self.assertEqual(inc["revenue_cents"], 5000)
+        self.assertEqual(inc["operating_cost_cents"], 1500)
+        self.assertEqual(inc["net_profit_cents"], 3500)
+        self.assertEqual(inc["net_margin_pct"], 70.0)
+        self.assertEqual(inc["balance_cents"], 10000 + 5000 - 1500)
+        # vendor breakdown sorted by amount desc
+        self.assertEqual(list(inc["expense_by_vendor"].keys())[0], "nvidia-nemotron")
+
+    def test_empty(self):
+        inc = income_statement([])
+        self.assertEqual(inc["revenue_cents"], 0)
+        self.assertEqual(inc["net_margin_pct"], 0.0)
+
+
+class TestUnitEconomics(unittest.TestCase):
+    def test_per_job_averages(self):
+        entries = [
+            _e("revenue", 6000, job_id="J1"), _e("expense", 1000, job_id="J1"),
+            _e("revenue", 4000, job_id="J2"), _e("expense", 1000, job_id="J2"),
+        ]
+        ue = unit_economics(entries)
+        self.assertEqual(ue["completed_jobs"], 2)
+        self.assertEqual(ue["avg_revenue_cents"], 5000)
+        self.assertEqual(ue["avg_cost_cents"], 1000)
+        self.assertEqual(ue["avg_profit_cents"], 4000)
+        self.assertEqual(ue["contribution_margin_pct"], 80.0)
+
+    def test_no_completed_jobs(self):
+        ue = unit_economics([_e("expense", 100, job_id="J1")])  # cost but no revenue
+        self.assertEqual(ue["completed_jobs"], 0)
+        self.assertEqual(ue["avg_profit_cents"], 0)
+
+
+class TestRunway(unittest.TestCase):
+    def test_idle_when_only_capital(self):
+        rw = runway([_e("capital", 10000)])
+        self.assertEqual(rw["status"], "idle")
+        self.assertIsNone(rw["runway_days"])
+
+    def test_insufficient_history(self):
+        # two ops within a few minutes -> no reliable daily rate
+        rw = runway([_e("revenue", 100, ts=0), _e("expense", 50, ts=120)])
+        self.assertEqual(rw["status"], "insufficient_history")
+        self.assertIsNone(rw["daily_net_cents"])
+
+    def test_cashflow_positive(self):
+        rw = runway([_e("revenue", 5000, ts=0), _e("expense", 1000, ts=2 * DAY)])
+        self.assertEqual(rw["status"], "cashflow_positive")
+        self.assertTrue(rw["cashflow_positive"])
+        self.assertIsNone(rw["runway_days"])
+        self.assertGreater(rw["daily_net_cents"], 0)
+
+    def test_burning_computes_runway(self):
+        # seed 10000, then net burn of 4000 over 2 days -> 2000/day burn.
+        entries = [
+            _e("capital", 10000, ts=0),
+            _e("revenue", 1000, ts=0),
+            _e("expense", 5000, ts=2 * DAY),
+        ]
+        rw = runway(entries, reserve_cents=2000)
+        self.assertEqual(rw["status"], "burning")
+        self.assertFalse(rw["cashflow_positive"])
+        # balance = 6000, spendable above reserve = 4000, burn 2000/day -> 2.0 days
+        self.assertEqual(rw["balance_cents"], 6000)
+        self.assertEqual(rw["runway_days"], 2.0)
+
+
+class TestSparkline(unittest.TestCase):
+    def test_monotonic_series(self):
+        spark = sparkline([0, 1, 2, 3, 4, 5, 6, 7])
+        self.assertEqual(len(spark), 8)
+        self.assertEqual(spark[0], "▁")
+        self.assertEqual(spark[-1], "█")
+
+    def test_flat_and_empty(self):
+        self.assertEqual(sparkline([5, 5, 5]), "▁▁▁")
+        self.assertEqual(sparkline([]), "")
+
+    def test_balance_series_downsamples(self):
+        entries = [_e("revenue", 1, ts=i) for i in range(100)]
+        self.assertLessEqual(len(balance_series(entries, buckets=10)), 10)
+
+
+class TestReport(unittest.TestCase):
+    def test_build_and_format(self):
+        entries = [
+            _e("capital", 10000, ts=0),
+            _e("revenue", 5000, job_id="J1", ts=0),
+            _e("expense", 1000, job_id="J1", vendor="nvidia-nemotron", ts=2 * DAY),
+        ]
+        report = build_report(entries, reserve_cents=2000)
+        self.assertIn("income_statement", report)
+        self.assertIn("unit_economics", report)
+        self.assertIn("runway", report)
+        text = format_report(report)
+        self.assertIn("Financial Report", text)
+        self.assertIn("Net profit", text)
+        self.assertIn("Unit economics", text)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What & why

SOLVENT's pitch is "an agent that runs as a profitable business" — but until now it could *book* P&L without being able to *report* on it. This adds the financial-intelligence layer a real business steers by, plus fixes a latent CLI bug found along the way.

## New: `python -m solvent finance` (alias `report`)

A report computed purely from the treasury ledger (pure functions, no DB needed → trivially testable):

- **Income statement** — revenue, operating cost, net profit, margin, with a per-vendor cost breakdown.
- **Unit economics** — average revenue / cost / profit and contribution margin *per completed job*. Meaningful even after a 30-second demo, unlike a time-based rate.
- **Cash runway** — from the operating burn/gain rate: days-to-reserve when burning, or **`cash-flow positive`** once the agent funds itself. Declines to project a daily rate when there's too little time history (honest, not fake-precise).
- **Balance sparkline** — the treasury trajectory at a glance.
- `--json` for machine-readable output; `--reserve <usd>` to set the cash floor.

Sample output:
```
Income statement
  Revenue            $223.00
  Operating cost     $1.65
  Net profit         $221.35  (99.3% margin)
  Cash balance       $321.35  (seed $100.00)
Unit economics (per completed job)
  Completed jobs     3
  Avg profit         $73.78  (99.3% contribution)
Balance trajectory  ▁▂▂▂▂▄▄▄▄█▇▇▇
```

## Fix: subcommand routing was broken

`from .cli import main` in `solvent/__main__.py` shadowed the subcommand router, so **every documented subcommand** (`serve`, `worker`, `tune`, `reconcile`, `doctor`, `telegram`, `pairing`, `workspace`, `retry`, `webhooks`) silently fell through to the demo CLI — e.g. `python -m solvent doctor` errored with `unrecognized arguments: doctor`. Removed the shadow; routing is restored and covered by a regression test.

## Verification
- `pytest tests/` → **266 passed, 6 skipped** (+16 new tests).
- Manually confirmed `python -m solvent doctor` now routes and `python -m solvent finance` renders the report end-to-end on a seeded treasury.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01SGjM79GJpSksy9wSSBa7e6)_