### PR TITLE
Net P&L trend by day/week/month in the finance report

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,12 +197,13 @@ python3 -m solvent tune --apply             # apply after 5+ completed jobs
 python3 -m solvent finance                # income statement, unit economics, runway
 python3 -m solvent finance --json         # machine-readable report
 python3 -m solvent finance --reserve 50   # runway to a $50 cash-reserve floor
+python3 -m solvent finance --period week  # net P&L trend by day | week | month
 ```
 
 `finance` (alias `report`) turns the treasury ledger into the numbers a
-business steers by: revenue/cost/net-margin, average profit per job, and a cash
+business steers by: revenue/cost/net-margin, average profit per job, a cash
 **runway** — days of burn remaining, or `cash-flow positive` once the agent
-funds itself.
+funds itself — and a **net-P&L trend** bucketed by day, week, or month.
 
 ---
 

--- a/solvent/finance.py
+++ b/solvent/finance.py
@@ -17,12 +17,15 @@ pure and trivially testable without a database. Exposed on the CLI as
 
 from __future__ import annotations
 
+import datetime
 import json
 import sys
 import time
 from typing import Iterable, Optional
 
 from .treasury import LedgerEntry, Treasury, fmt
+
+_PERIODS = ("day", "week", "month")
 
 # Below this much elapsed history a daily burn/gain rate is statistical noise,
 # so we decline to project a runway rather than quote a meaningless number.
@@ -175,7 +178,60 @@ def sparkline(values: list[int]) -> str:
     )
 
 
-def build_report(entries: Iterable[LedgerEntry], *, reserve_cents: int = 0) -> dict:
+def _period_key(ts: float, period: str) -> str:
+    dt = datetime.datetime.fromtimestamp(ts, tz=datetime.timezone.utc)
+    if period == "day":
+        return dt.strftime("%Y-%m-%d")
+    if period == "week":
+        iso = dt.isocalendar()
+        return f"{iso[0]}-W{iso[1]:02d}"
+    if period == "month":
+        return dt.strftime("%Y-%m")
+    raise ValueError(f"unknown period {period!r}; expected one of {_PERIODS}")
+
+
+def period_pnl(entries: Iterable[LedgerEntry], period: str = "day") -> list[dict]:
+    """Net P&L bucketed by calendar period, in chronological order.
+
+    Each bucket carries revenue, operating cost, net profit (capital excluded),
+    and the running ending cash balance (capital included) at period close.
+    """
+    if period not in _PERIODS:
+        raise ValueError(f"unknown period {period!r}; expected one of {_PERIODS}")
+
+    buckets: dict[str, dict] = {}
+    order: list[str] = []
+    for e in sorted(entries, key=lambda e: e.ts):
+        key = _period_key(e.ts, period)
+        if key not in buckets:
+            buckets[key] = {
+                "period": key, "revenue_cents": 0, "operating_cost_cents": 0,
+                "net_cents": 0, "capital_cents": 0,
+            }
+            order.append(key)
+        b = buckets[key]
+        if e.kind == "revenue":
+            b["revenue_cents"] += e.amount_cents
+            b["net_cents"] += e.amount_cents
+        elif e.kind == "expense":
+            b["operating_cost_cents"] += e.amount_cents
+            b["net_cents"] -= e.amount_cents
+        else:  # capital
+            b["capital_cents"] += e.amount_cents
+
+    running = 0
+    out = []
+    for key in order:
+        b = buckets[key]
+        running += b["net_cents"] + b["capital_cents"]
+        b["ending_balance_cents"] = running
+        out.append(b)
+    return out
+
+
+def build_report(
+    entries: Iterable[LedgerEntry], *, reserve_cents: int = 0, period: str = "day"
+) -> dict:
     """Assemble the full financial picture as a JSON-serialisable dict."""
     entries = list(entries)
     return {
@@ -183,6 +239,8 @@ def build_report(entries: Iterable[LedgerEntry], *, reserve_cents: int = 0) -> d
         "unit_economics": unit_economics(entries),
         "runway": runway(entries, reserve_cents=reserve_cents),
         "balance_sparkline": sparkline(balance_series(entries)),
+        "period": period,
+        "period_pnl": period_pnl(entries, period),
     }
 
 
@@ -237,23 +295,50 @@ def format_report(report: dict) -> str:
     spark = report.get("balance_sparkline")
     if spark:
         lines += ["", f"Balance trajectory  {spark}"]
+
+    trend = report.get("period_pnl") or []
+    if trend:
+        period = report.get("period", "day")
+        recent = trend[-12:]
+        lines += ["", f"Net P&L by {period} (last {len(recent)})"]
+        for b in recent:
+            sign = "+" if b["net_cents"] >= 0 else "-"
+            lines.append(
+                f"  {b['period']:<11} net {sign}{fmt(abs(b['net_cents']))}"
+                f"   (rev {fmt(b['revenue_cents'])} / cost {fmt(b['operating_cost_cents'])})"
+                f"   bal {fmt(b['ending_balance_cents'])}"
+            )
+        net_spark = sparkline([b["net_cents"] for b in recent])
+        if net_spark:
+            lines += ["", f"Net P&L trend       {net_spark}"]
     return "\n".join(lines)
 
 
 def main() -> None:
-    """CLI: ``python -m solvent finance [--json] [--reserve USD]``."""
+    """CLI: ``python -m solvent finance [--json] [--reserve USD] [--period P]``."""
     args = sys.argv[1:]
     as_json = "--json" in args
     reserve_cents = 0
+    period = "day"
+    usage = "Usage: python -m solvent finance [--json] [--reserve <usd>] [--period day|week|month]"
     if "--reserve" in args:
         try:
             reserve_cents = int(float(args[args.index("--reserve") + 1]) * 100)
         except (ValueError, IndexError):
-            print("Usage: python -m solvent finance [--json] [--reserve <usd>]")
+            print(usage)
+            sys.exit(1)
+    if "--period" in args:
+        try:
+            period = args[args.index("--period") + 1]
+        except IndexError:
+            print(usage)
+            sys.exit(1)
+        if period not in _PERIODS:
+            print(usage)
             sys.exit(1)
 
     entries = Treasury().entries
-    report = build_report(entries, reserve_cents=reserve_cents)
+    report = build_report(entries, reserve_cents=reserve_cents, period=period)
     if as_json:
         print(json.dumps(report, indent=2))
     else:

--- a/tests/test_finance.py
+++ b/tests/test_finance.py
@@ -8,12 +8,16 @@ from solvent.finance import (
     runway,
     balance_series,
     sparkline,
+    period_pnl,
     build_report,
     format_report,
 )
 from solvent.treasury import LedgerEntry
 
 DAY = 86_400.0
+# 2021-01-01 00:00:00 UTC and 2021-01-02 00:00:00 UTC
+T_JAN1 = 1_609_459_200.0
+T_JAN2 = T_JAN1 + DAY
 
 
 def _e(kind, cents, *, job_id=None, vendor=None, ts=0.0):
@@ -112,6 +116,35 @@ class TestSparkline(unittest.TestCase):
         self.assertLessEqual(len(balance_series(entries, buckets=10)), 10)
 
 
+class TestPeriodPnl(unittest.TestCase):
+    def test_buckets_by_day_with_running_balance(self):
+        entries = [
+            _e("capital", 10000, ts=T_JAN1),
+            _e("revenue", 5000, job_id="J1", ts=T_JAN1),
+            _e("expense", 1000, job_id="J1", vendor="v", ts=T_JAN1),
+            _e("revenue", 3000, job_id="J2", ts=T_JAN2),
+            _e("expense", 2000, job_id="J2", vendor="v", ts=T_JAN2),
+        ]
+        rows = period_pnl(entries, "day")
+        self.assertEqual(len(rows), 2)
+        self.assertEqual(rows[0]["period"], "2021-01-01")
+        self.assertEqual(rows[0]["net_cents"], 4000)        # 5000 - 1000
+        self.assertEqual(rows[0]["ending_balance_cents"], 14000)  # +10000 capital
+        self.assertEqual(rows[1]["net_cents"], 1000)        # 3000 - 2000
+        self.assertEqual(rows[1]["ending_balance_cents"], 15000)
+
+    def test_month_bucketing(self):
+        rows = period_pnl([_e("revenue", 100, ts=T_JAN1)], "month")
+        self.assertEqual(rows[0]["period"], "2021-01")
+
+    def test_invalid_period_raises(self):
+        with self.assertRaises(ValueError):
+            period_pnl([], "fortnight")
+
+    def test_empty(self):
+        self.assertEqual(period_pnl([], "day"), [])
+
+
 class TestReport(unittest.TestCase):
     def test_build_and_format(self):
         entries = [
@@ -119,14 +152,17 @@ class TestReport(unittest.TestCase):
             _e("revenue", 5000, job_id="J1", ts=0),
             _e("expense", 1000, job_id="J1", vendor="nvidia-nemotron", ts=2 * DAY),
         ]
-        report = build_report(entries, reserve_cents=2000)
+        report = build_report(entries, reserve_cents=2000, period="day")
         self.assertIn("income_statement", report)
         self.assertIn("unit_economics", report)
         self.assertIn("runway", report)
+        self.assertIn("period_pnl", report)
+        self.assertEqual(report["period"], "day")
         text = format_report(report)
         self.assertIn("Financial Report", text)
         self.assertIn("Net profit", text)
         self.assertIn("Unit economics", text)
+        self.assertIn("Net P&L by day", text)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## What & why

Builds on the merged `finance` command (#27) with **period trends** — so the agent can show its P&L *over time*, not just in aggregate.

## Changes

- `period_pnl(entries, period)` — buckets revenue, operating cost, and net profit by calendar **day / week / month** (UTC), each with a running ending cash balance (capital included).
- `build_report()` now includes the trend; `format_report()` renders the last 12 periods plus a net-P&L sparkline.
- CLI: `python -m solvent finance --period day|week|month` (default `day`).

Sample:
```
Net P&L by day (last 1)
  2026-06-26  net +$221.35   (rev $223.00 / cost $1.65)   bal $321.35

Net P&L trend       ▁
```

## Verification
- `pytest tests/` → **270 passed, 6 skipped** (+4 new tests: day/month bucketing, running balance, invalid-period guard, rendered trend).
- Smoke-tested `python -m solvent finance --period day` on a seeded treasury.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01SGjM79GJpSksy9wSSBa7e6)_