### PR TITLE
Balance forecast with best/worst band (finance report + dashboard)

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,12 +198,16 @@ python3 -m solvent finance                # income statement, unit economics, ru
 python3 -m solvent finance --json         # machine-readable report
 python3 -m solvent finance --reserve 50   # runway to a $50 cash-reserve floor
 python3 -m solvent finance --period week  # net P&L trend by day | week | month
+python3 -m solvent finance --horizon 60   # forecast the balance 60 days out
 ```
 
 `finance` (alias `report`) turns the treasury ledger into the numbers a
 business steers by: revenue/cost/net-margin, average profit per job, a cash
 **runway** — days of burn remaining, or `cash-flow positive` once the agent
-funds itself — and a **net-P&L trend** bucketed by day, week, or month.
+funds itself — a **net-P&L trend** bucketed by day/week/month, and a
+**balance forecast** (central projection with a best/worst band whose width
+grows with daily volatility). The income statement, runway, trend, and
+forecast also render as a **Financial Statement** panel in the HTML dashboard.
 
 ---
 

--- a/solvent/dashboard.py
+++ b/solvent/dashboard.py
@@ -400,6 +400,16 @@ def _financials_html(report: dict) -> str:
         runway_txt = "No activity yet"
     parts.append(row("Runway", h(runway_txt)))
 
+    fc = report.get("forecast")
+    if fc and fc.get("status") == "ok":
+        proj_cls = "green-txt" if fc["projected_balance_cents"] >= fc["balance_cents"] else "red-txt"
+        parts.append(
+            row(f"Projected balance ({fc['horizon_days']}d)", fmt(fc["projected_balance_cents"]), proj_cls)
+        )
+        parts.append(
+            row("Forecast best / worst", f"{fmt(fc['best_cents'])} / {fmt(fc['worst_cents'])}")
+        )
+
     out = "".join(parts)
 
     trend = report.get("period_pnl") or []

--- a/solvent/finance.py
+++ b/solvent/finance.py
@@ -229,8 +229,55 @@ def period_pnl(entries: Iterable[LedgerEntry], period: str = "day") -> list[dict
     return out
 
 
+def forecast(entries: Iterable[LedgerEntry], *, horizon_days: int = 30) -> dict:
+    """Project the cash balance ``horizon_days`` out, with a best/worst band.
+
+    Models daily net P&L as a random walk: the central projection extends the
+    mean daily net, and the band widens with the daily volatility scaled by
+    ``sqrt(horizon)`` (so uncertainty grows over time, not linearly). Based on
+    *active* days, so it assumes a similar working cadence continues.
+    """
+    entries = list(entries)
+    balance = sum(_signed(e) for e in entries)
+    base = {
+        "horizon_days": horizon_days,
+        "balance_cents": balance,
+        "daily_mean_cents": None,
+        "daily_volatility_cents": None,
+        "projected_balance_cents": None,
+        "best_cents": None,
+        "worst_cents": None,
+        "status": "insufficient_history",
+    }
+
+    daily = period_pnl(entries, "day")
+    nets = [b["net_cents"] for b in daily]
+    if len(nets) < 2 or horizon_days <= 0:
+        return base
+
+    mean = sum(nets) / len(nets)
+    variance = sum((n - mean) ** 2 for n in nets) / (len(nets) - 1)
+    std = variance ** 0.5
+    band = std * (horizon_days ** 0.5)
+    projected = balance + mean * horizon_days
+
+    base.update(
+        status="ok",
+        daily_mean_cents=round(mean),
+        daily_volatility_cents=round(std),
+        projected_balance_cents=round(projected),
+        best_cents=round(projected + band),
+        worst_cents=round(projected - band),
+    )
+    return base
+
+
 def build_report(
-    entries: Iterable[LedgerEntry], *, reserve_cents: int = 0, period: str = "day"
+    entries: Iterable[LedgerEntry],
+    *,
+    reserve_cents: int = 0,
+    period: str = "day",
+    horizon_days: int = 30,
 ) -> dict:
     """Assemble the full financial picture as a JSON-serialisable dict."""
     entries = list(entries)
@@ -241,6 +288,7 @@ def build_report(
         "balance_sparkline": sparkline(balance_series(entries)),
         "period": period,
         "period_pnl": period_pnl(entries, period),
+        "forecast": forecast(entries, horizon_days=horizon_days),
     }
 
 
@@ -292,6 +340,18 @@ def format_report(report: dict) -> str:
             f"(to {fmt(rw['reserve_cents'])} reserve)."
         )
 
+    fc = report.get("forecast")
+    if fc:
+        lines += ["", f"Forecast ({fc['horizon_days']}d)"]
+        if fc["status"] != "ok":
+            lines.append("  Insufficient history to project a balance.")
+        else:
+            lines += [
+                f"  Daily net (mean)   {fmt(fc['daily_mean_cents'])}  (±{fmt(fc['daily_volatility_cents'])} vol)",
+                f"  Projected balance  {fmt(fc['projected_balance_cents'])}",
+                f"  Best / worst       {fmt(fc['best_cents'])} / {fmt(fc['worst_cents'])}",
+            ]
+
     spark = report.get("balance_sparkline")
     if spark:
         lines += ["", f"Balance trajectory  {spark}"]
@@ -320,7 +380,11 @@ def main() -> None:
     as_json = "--json" in args
     reserve_cents = 0
     period = "day"
-    usage = "Usage: python -m solvent finance [--json] [--reserve <usd>] [--period day|week|month]"
+    horizon_days = 30
+    usage = (
+        "Usage: python -m solvent finance [--json] [--reserve <usd>] "
+        "[--period day|week|month] [--horizon <days>]"
+    )
     if "--reserve" in args:
         try:
             reserve_cents = int(float(args[args.index("--reserve") + 1]) * 100)
@@ -336,9 +400,20 @@ def main() -> None:
         if period not in _PERIODS:
             print(usage)
             sys.exit(1)
+    if "--horizon" in args:
+        try:
+            horizon_days = int(args[args.index("--horizon") + 1])
+        except (ValueError, IndexError):
+            print(usage)
+            sys.exit(1)
+        if horizon_days <= 0:
+            print(usage)
+            sys.exit(1)
 
     entries = Treasury().entries
-    report = build_report(entries, reserve_cents=reserve_cents, period=period)
+    report = build_report(
+        entries, reserve_cents=reserve_cents, period=period, horizon_days=horizon_days
+    )
     if as_json:
         print(json.dumps(report, indent=2))
     else:

--- a/tests/test_dashboard_financials.py
+++ b/tests/test_dashboard_financials.py
@@ -43,6 +43,18 @@ class TestFinancialsHtml(unittest.TestCase):
         self.assertIn("green-txt", html)  # positive net profit
         self.assertNotIn("<script", html)
 
+    def test_forecast_rendered_when_enough_history(self):
+        from solvent.treasury import LedgerEntry
+        DAY = 86_400.0
+        entries = [
+            LedgerEntry("capital", 10000, "seed", ts=0),
+            LedgerEntry("revenue", 1000, "j1", job_id="J1", ts=0),
+            LedgerEntry("revenue", 1000, "j2", job_id="J2", ts=DAY),
+        ]
+        html = dashboard._financials_html(build_report(entries, horizon_days=10))
+        self.assertIn("Projected balance", html)
+        self.assertIn("Forecast best / worst", html)
+
 
 class TestRenderIncludesPanel(unittest.TestCase):
     def test_render_emits_financials_panel(self):

--- a/tests/test_finance.py
+++ b/tests/test_finance.py
@@ -9,6 +9,7 @@ from solvent.finance import (
     balance_series,
     sparkline,
     period_pnl,
+    forecast,
     build_report,
     format_report,
 )
@@ -145,6 +146,44 @@ class TestPeriodPnl(unittest.TestCase):
         self.assertEqual(period_pnl([], "day"), [])
 
 
+class TestForecast(unittest.TestCase):
+    def test_insufficient_history(self):
+        fc = forecast([_e("revenue", 100, ts=T_JAN1)])  # one active day
+        self.assertEqual(fc["status"], "insufficient_history")
+        self.assertIsNone(fc["projected_balance_cents"])
+
+    def test_projects_from_steady_daily_net(self):
+        # +$10/day for two days, zero volatility -> linear projection, tight band
+        entries = [
+            _e("capital", 10000, ts=T_JAN1),
+            _e("revenue", 1000, job_id="J1", ts=T_JAN1),
+            _e("revenue", 1000, job_id="J2", ts=T_JAN2),
+        ]
+        fc = forecast(entries, horizon_days=10)
+        self.assertEqual(fc["status"], "ok")
+        self.assertEqual(fc["daily_mean_cents"], 1000)
+        self.assertEqual(fc["daily_volatility_cents"], 0)
+        # balance 12000 + 1000*10 = 22000, no volatility -> best==worst==projected
+        self.assertEqual(fc["projected_balance_cents"], 22000)
+        self.assertEqual(fc["best_cents"], 22000)
+        self.assertEqual(fc["worst_cents"], 22000)
+
+    def test_volatility_widens_band(self):
+        entries = [
+            _e("capital", 10000, ts=T_JAN1),
+            _e("revenue", 2000, job_id="J1", ts=T_JAN1),
+            _e("expense", 1000, job_id="J2", vendor="v", ts=T_JAN2),
+        ]
+        fc = forecast(entries, horizon_days=9)
+        self.assertEqual(fc["status"], "ok")
+        self.assertGreater(fc["best_cents"], fc["projected_balance_cents"])
+        self.assertLess(fc["worst_cents"], fc["projected_balance_cents"])
+
+    def test_nonpositive_horizon(self):
+        entries = [_e("revenue", 100, ts=T_JAN1), _e("revenue", 100, ts=T_JAN2)]
+        self.assertEqual(forecast(entries, horizon_days=0)["status"], "insufficient_history")
+
+
 class TestReport(unittest.TestCase):
     def test_build_and_format(self):
         entries = [
@@ -157,12 +196,14 @@ class TestReport(unittest.TestCase):
         self.assertIn("unit_economics", report)
         self.assertIn("runway", report)
         self.assertIn("period_pnl", report)
+        self.assertIn("forecast", report)
         self.assertEqual(report["period"], "day")
         text = format_report(report)
         self.assertIn("Financial Report", text)
         self.assertIn("Net profit", text)
         self.assertIn("Unit economics", text)
         self.assertIn("Net P&L by day", text)
+        self.assertIn("Forecast", text)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## What & why

Extends the finance layer with **forecasting** — projecting where the treasury balance is headed, not just where it's been.

## Changes

- `forecast(entries, horizon_days)` models daily net P&L as a **random walk**: the central projection extends the mean daily net, and the **best/worst band** widens with daily volatility scaled by `sqrt(horizon)` — so uncertainty grows over time rather than linearly. Returns `insufficient_history` with fewer than 2 active days (honest, not fake-precise).
- `build_report()` includes the forecast; `format_report()` renders it; CLI gains `--horizon <days>` (default 30).
- The dashboard **Financial Statement** panel shows the projected balance and best/worst band when there's enough history.

Sample (with multi-day history):
```
Forecast (30d)
  Daily net (mean)   $73.78  (±$0.00 vol)
  Projected balance  $2,534.75
  Best / worst       $2,534.75 / $2,534.75
```

## Verification
- `pytest tests/` → **279 passed, 6 skipped** (+5 new: steady-rate projection where the zero-volatility band collapses, volatility widening the band, insufficient-history/non-positive-horizon guards, report + dashboard integration).
- Smoke-tested `python -m solvent finance --horizon 60` (correctly reports insufficient history for the single-day demo run).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01SGjM79GJpSksy9wSSBa7e6)_