### PR TITLE
Make SOLVENT a pip-installable package with a `solvent` command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,12 @@ __pycache__/
 .pytest_cache/
 .DS_Store
 
+# Python packaging artifacts
+build/
+dist/
+*.egg-info/
+*.egg
+
 # Virtual Environment
 .venv/
 venv/

--- a/README.md
+++ b/README.md
@@ -44,6 +44,31 @@ python3 run_demo.py
 
 The agent will run a full batch of 4 analyst jobs — complete with margin gating, Stripe payment simulation, NVIDIA Nemotron fulfillment, guardrail screening, and live P&L — in about 30 seconds.
 
+### Install as a package (optional)
+
+The core runs on the **standard library alone**, so a bare install pulls in
+nothing extra and gives you a `solvent` command:
+
+```bash
+pip install -e .                 # editable install from a checkout
+# or once published:  pipx install solvent-agent
+
+solvent                          # run the demo
+solvent finance                  # financial report (income, runway, forecast)
+solvent --help                   # list all commands
+solvent --version
+```
+
+Third-party features are **opt-in extras** — install only what you need:
+
+```bash
+pip install -e ".[stripe]"       # real Stripe test-mode payment links
+pip install -e ".[serve]"        # FastAPI webhooks + hosted briefs
+pip install -e ".[telegram]"     # Telegram bot channel
+pip install -e ".[rich]"         # live terminal dashboard (solvent tui)
+pip install -e ".[all]"          # everything
+```
+
 > **First run**: A short onboarding wizard asks you to choose a model, interaction mode, and whether to enable Stripe test mode. Preferences are saved to `.solvent/config.json` and never committed.
 
 ---
@@ -296,6 +321,7 @@ solvent/
   service.py       the product: an on-demand research brief
   jobs.py          sample inbound work
   dashboard.py     renders the treasury to HTML + JSON
+  finance.py       income statement · unit economics · runway · forecast
   config.py        onboarding wizard and config persistence
   gateway.py       channel router (Telegram → chat sessions)
   chat.py          conversational loop + business tools

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,51 @@
+[build-system]
+requires = ["setuptools>=61.0"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "solvent-agent"
+description = "A self-funding analyst agent: earns on Stripe, fulfils with NVIDIA Nemotron, spends within guardrails."
+readme = "README.md"
+license = { text = "MIT" }
+requires-python = ">=3.10"
+dynamic = ["version"]
+keywords = ["agent", "stripe", "nvidia", "nemotron", "llm", "treasury"]
+classifiers = [
+    "Programming Language :: Python :: 3",
+    "License :: OSI Approved :: MIT License",
+    "Operating System :: OS Independent",
+    "Intended Audience :: Developers",
+]
+# Core runs on the standard library alone (offline stubs). Everything that
+# needs a third-party package is an opt-in extra below.
+dependencies = []
+
+[project.optional-dependencies]
+stripe = ["stripe>=9.0.0"]
+rich = ["rich>=13.0.0"]
+serve = ["fastapi>=0.110.0", "uvicorn[standard]>=0.27.0"]
+telegram = ["python-telegram-bot>=21.0"]
+dev = ["pytest>=7.0.0"]
+all = [
+    "stripe>=9.0.0",
+    "rich>=13.0.0",
+    "fastapi>=0.110.0",
+    "uvicorn[standard]>=0.27.0",
+    "python-telegram-bot>=21.0",
+]
+
+[project.scripts]
+solvent = "solvent.__main__:main"
+
+[project.urls]
+Homepage = "https://github.com/ianalloway/solvent-agent"
+Repository = "https://github.com/ianalloway/solvent-agent"
+
+[tool.setuptools.dynamic]
+version = { attr = "solvent.__version__" }
+
+[tool.setuptools.packages.find]
+include = ["solvent*"]
+
+[tool.setuptools.package-data]
+solvent = ["templates/**/*"]

--- a/solvent/__main__.py
+++ b/solvent/__main__.py
@@ -2,8 +2,44 @@
 
 import sys
 
+HELP = """\
+SOLVENT — a self-funding analyst agent.
+
+Usage: solvent <command> [options]
+       solvent                 run the demo (interactive onboarding on first run)
+
+Commands:
+  (none)        run the batch demo / interactive session
+  serve         webhooks + job API + hosted briefs
+  worker        resume incomplete jobs, process the queue
+  telegram      long-poll the Telegram bot
+  finance       income statement, unit economics, runway, forecast (alias: report)
+  tune          propose pricing improvements (--apply to commit)
+  reconcile     Stripe <-> ledger drift check
+  doctor        stack diagnostics
+  pairing       manage Telegram DM pairing codes
+  workspace     seed the agent workspace (SOUL/BRAIN/AGENTS)
+  retry <id>    re-run a stuck job
+  webhooks      inspect the webhook event log (stats|list|failed)
+  help          show this message
+  version       print the installed version
+
+Run `solvent <command> --help` where supported for command-specific options.
+"""
+
+
+def _print_version():
+    from . import __version__
+    print(f"solvent {__version__}")
+
 
 def main():
+    if len(sys.argv) > 1 and sys.argv[1] in ("version", "--version", "-V"):
+        _print_version()
+        return
+    if len(sys.argv) > 1 and sys.argv[1] in ("help", "--help", "-h"):
+        print(HELP)
+        return
     if len(sys.argv) > 1 and sys.argv[1] == "serve":
         sys.argv.pop(1)
         from .server import main as serve_main

--- a/tests/test_cli_routing.py
+++ b/tests/test_cli_routing.py
@@ -39,6 +39,33 @@ class TestCliRouting(unittest.TestCase):
             entry.main()
         mock_demo.assert_called_once()
 
+    def test_version_prints_and_does_not_run_demo(self):
+        import io
+        from contextlib import redirect_stdout
+        from solvent import __version__
+
+        for argv in (["solvent", "version"], ["solvent", "--version"], ["solvent", "-V"]):
+            buf = io.StringIO()
+            with patch.object(entry.sys, "argv", argv), \
+                 patch("solvent.cli.main") as mock_demo, redirect_stdout(buf):
+                entry.main()
+            self.assertIn(__version__, buf.getvalue())
+            mock_demo.assert_not_called()
+
+    def test_help_lists_subcommands(self):
+        import io
+        from contextlib import redirect_stdout
+
+        buf = io.StringIO()
+        with patch.object(entry.sys, "argv", ["solvent", "help"]), \
+             patch("solvent.cli.main") as mock_demo, redirect_stdout(buf):
+            entry.main()
+        out = buf.getvalue()
+        self.assertIn("Commands:", out)
+        self.assertIn("finance", out)
+        self.assertIn("serve", out)
+        mock_demo.assert_not_called()
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -1,0 +1,48 @@
+"""Sanity checks for the installable package metadata."""
+
+import sys
+import unittest
+from pathlib import Path
+
+if sys.version_info >= (3, 11):
+    import tomllib
+else:  # pragma: no cover
+    tomllib = None
+
+ROOT = Path(__file__).resolve().parent.parent
+PYPROJECT = ROOT / "pyproject.toml"
+
+
+class TestPackaging(unittest.TestCase):
+    def test_pyproject_exists(self):
+        self.assertTrue(PYPROJECT.is_file())
+
+    def test_version_attr_present(self):
+        import solvent
+        self.assertRegex(solvent.__version__, r"^\d+\.\d+\.\d+")
+
+    @unittest.skipIf(tomllib is None, "tomllib requires Python 3.11+")
+    def test_console_script_and_extras_declared(self):
+        data = tomllib.loads(PYPROJECT.read_text())
+        scripts = data["project"]["scripts"]
+        self.assertEqual(scripts["solvent"], "solvent.__main__:main")
+        # core has no hard deps; functionality is opt-in via extras
+        self.assertEqual(data["project"]["dependencies"], [])
+        extras = data["project"]["optional-dependencies"]
+        for name in ("serve", "telegram", "stripe", "rich", "dev", "all"):
+            self.assertIn(name, extras)
+
+    @unittest.skipIf(tomllib is None, "tomllib requires Python 3.11+")
+    def test_templates_shipped_as_package_data(self):
+        data = tomllib.loads(PYPROJECT.read_text())
+        pkg_data = data["tool"]["setuptools"]["package-data"]
+        self.assertIn("solvent", pkg_data)
+        self.assertTrue(any("templates" in p for p in pkg_data["solvent"]))
+
+    def test_main_entry_point_importable(self):
+        from solvent.__main__ import main
+        self.assertTrue(callable(main))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What & why

The project could only be run from a source checkout (`python3 run_demo.py` / `python -m solvent`). This makes it a **proper installable package** with a real `solvent` command, while keeping the "zero dependencies" promise intact.

## Changes

- **`pyproject.toml`** (PEP 621, setuptools):
  - Core has **no runtime deps** — offline stubs run on the stdlib. Third-party features are **opt-in extras**: `stripe`, `rich`, `serve`, `telegram`, `dev`, `all`.
  - Workspace templates ship as **package data**; version read dynamically from `solvent.__version__`.
- **Console entry point** `solvent = solvent.__main__:main` → `pip install -e .` / `pipx install` gives a real CLI.
- **CLI discoverability**: `solvent --version` / `version`, and `solvent help` / `--help` listing every subcommand (the router had no usage text before — and note it now works at all, after the routing fix in #27).
- `.gitignore` for build artifacts (`build/`, `dist/`, `*.egg-info`).
- README: pip-install + extras instructions; `finance.py` added to the layout.

```bash
pip install -e .            # core, zero extra deps
pip install -e ".[all]"     # everything
solvent --help             # lists all commands
solvent finance            # financial report
```

## Verification
- Did a real **editable install** and **wheel build**: all 10 workspace templates bundled, entry point registered, and `solvent version|help|finance` run via the console script.
- `pytest tests/` → **286 passed, 6 skipped** (+7 new: packaging metadata sanity — script/extras/package-data/version — and version/help routing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01SGjM79GJpSksy9wSSBa7e6)_