### PR TITLE
CI: validate packaging + make the zero-dependency core test-clean

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,3 +25,38 @@ jobs:
       - name: Run tests
         run: |
           python -m pytest tests/ -v
+
+  core:
+    name: zero-dependency core
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: "pip"
+      - name: Install core + dev only (no optional extras)
+        run: pip install -e ".[dev]"
+      - name: Run tests
+        # The core runs on the stdlib alone; optional-extra tests skip cleanly.
+        run: python -m pytest -q
+
+  build:
+    name: build + install + CLI smoke
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: "pip"
+      - name: Build wheel and sdist
+        run: |
+          pip install build
+          python -m build
+      - name: Install the built wheel and smoke-test the CLI
+        run: |
+          pip install dist/*.whl
+          solvent --version
+          solvent help
+          solvent finance --json

--- a/solvent/tui.py
+++ b/solvent/tui.py
@@ -10,7 +10,6 @@ that refreshes every 2 seconds until Ctrl-C.
 
 from __future__ import annotations
 
-import sys
 import time
 from datetime import datetime
 from typing import TYPE_CHECKING
@@ -27,12 +26,11 @@ try:
     from rich.console import Console
     from rich.columns import Columns
     from rich import box
+    _RICH_AVAILABLE = True
 except ImportError:  # pragma: no cover
-    print(
-        "[SOLVENT] The 'rich' library is required for the terminal dashboard.\n"
-        "Install it with:  pip install rich"
-    )
-    sys.exit(1)
+    # Importing this module must never crash the interpreter — `rich` is an
+    # optional extra. Only `run()` actually needs it; report cleanly there.
+    _RICH_AVAILABLE = False
 
 if TYPE_CHECKING:
     from .treasury import Treasury
@@ -246,6 +244,13 @@ def run(treasury: "Treasury | None" = None, refresh_interval: float = 2.0) -> No
     refresh_interval:
         How often (in seconds) to poll the database for updates.
     """
+    if not _RICH_AVAILABLE:
+        print(
+            "[SOLVENT] The 'rich' library is required for the terminal dashboard.\n"
+            "Install it with:  pip install 'solvent-agent[rich]'  (or: pip install rich)"
+        )
+        return
+
     if treasury is None:
         from .treasury import Treasury
         treasury = Treasury()

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -6,6 +6,11 @@ import time
 import types
 from unittest.mock import MagicMock, patch
 
+import pytest
+
+# `rich` is an optional extra; skip the whole module when it isn't installed.
+pytest.importorskip("rich")
+
 
 # ---------------------------------------------------------------------------
 # Helpers: build minimal fake data that mirrors Treasury outputs

--- a/tests/test_tui_optional.py
+++ b/tests/test_tui_optional.py
@@ -1,0 +1,28 @@
+"""tui must import without `rich` installed and degrade cleanly.
+
+These tests intentionally do NOT importorskip rich — importing the module and
+calling run() must work (or fail gracefully) regardless of whether the
+optional extra is present.
+"""
+
+import io
+import unittest
+from contextlib import redirect_stdout
+from unittest.mock import patch
+
+from solvent import tui
+
+
+class TestTuiOptional(unittest.TestCase):
+    def test_import_does_not_crash(self):
+        self.assertTrue(callable(tui.run))
+
+    def test_run_degrades_when_rich_missing(self):
+        buf = io.StringIO()
+        with patch.object(tui, "_RICH_AVAILABLE", False), redirect_stdout(buf):
+            tui.run()  # must return cleanly, not raise/exit
+        self.assertIn("rich", buf.getvalue().lower())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What & why

The repo recently gained a CI workflow (full suite with all deps). This extends it to validate the new packaging, and removes a hidden hard dependency on `rich` so the "zero-dependency core" promise is actually enforced.

## Changes

- **`tui.py`**: no longer calls `sys.exit()` at import when `rich` is missing — it sets a flag, and `run()` prints an install hint and returns. Importing `solvent.tui` is now always safe (previously it crashed the interpreter, which made the whole test suite fail without `rich`).
- **Tests**: `test_tui` skips when `rich` is absent (`importorskip`); new `test_tui_optional` covers the graceful-degradation path regardless of `rich`.
- **CI**: keep the existing full-suite job and add two:
  - **zero-dependency core** — `pip install -e ".[dev]"`, proving the stdlib-only core is green (optional-extra tests skip cleanly).
  - **build** — builds the wheel, installs it, and smoke-tests the `solvent` console script (`--version`, `help`, `finance --json`).

## Verification (local)
- Suite green with **`rich` uninstalled**: `273 passed, 7 skipped` (tui tests skip).
- Suite green with extras present: `292 passed, 6 skipped`.
- Wheel build + install + `solvent` CLI confirmed earlier in the packaging work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01SGjM79GJpSksy9wSSBa7e6)_