### PR TITLE
add: solvent upgrade — PyPI version checker

### DIFF
--- a/solvent/__main__.py
+++ b/solvent/__main__.py
@@ -10,6 +10,7 @@ Usage: solvent <command> [options]
 
 Commands:
   (none)        run the batch demo / interactive session
+  upgrade       check for newer version on PyPI; --check exits 1 if outdated
   serve         webhooks + job API + hosted briefs
   worker        resume incomplete jobs, process the queue
   telegram      long-poll the Telegram bot
@@ -40,7 +41,11 @@ def main():
     if len(sys.argv) > 1 and sys.argv[1] in ("help", "--help", "-h"):
         print(HELP)
         return
-    if len(sys.argv) > 1 and sys.argv[1] == "serve":
+    if len(sys.argv) > 1 and sys.argv[1] == "upgrade":
+        sys.argv.pop(1)
+        from .upgrade import main as upgrade_main
+        upgrade_main()
+    elif len(sys.argv) > 1 and sys.argv[1] == "serve":
         sys.argv.pop(1)
         from .server import main as serve_main
         serve_main()

--- a/solvent/upgrade.py
+++ b/solvent/upgrade.py
@@ -1,0 +1,122 @@
+"""
+upgrade.py — version check and upgrade helper for SOLVENT.
+
+Usage:
+    solvent upgrade           print upgrade instructions if a newer version exists
+    solvent upgrade --check   exit 1 if current version is behind PyPI (CI-friendly)
+    solvent upgrade --install run pip install to upgrade in-place
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+import urllib.error
+import urllib.request
+from typing import Optional
+
+_PYPI_URL = "https://pypi.org/pypi/solvent-agent/json"
+_TIMEOUT = 5  # seconds
+
+
+def _parse_version(v: str) -> tuple[int, ...]:
+    """Parse 'X.Y.Z' into a comparable tuple; non-numeric parts become 0."""
+    parts = []
+    for seg in v.strip().lstrip("v").split("."):
+        try:
+            parts.append(int(seg))
+        except ValueError:
+            parts.append(0)
+    return tuple(parts)
+
+
+def current_version() -> str:
+    from . import __version__
+    return __version__
+
+
+def latest_pypi_version() -> Optional[str]:
+    """Fetch the latest release version from PyPI. Returns None on any error."""
+    try:
+        req = urllib.request.Request(
+            _PYPI_URL,
+            headers={"User-Agent": "solvent-agent/upgrade-check"},
+        )
+        with urllib.request.urlopen(req, timeout=_TIMEOUT) as resp:
+            data = json.loads(resp.read().decode())
+        return data["info"]["version"]
+    except (urllib.error.URLError, KeyError, json.JSONDecodeError, OSError):
+        return None
+
+
+def check_upgrade(*, quiet: bool = False) -> dict:
+    """
+    Compare current version to latest on PyPI.
+
+    Returns a dict with keys: current, latest, up_to_date, error.
+    """
+    current = current_version()
+    latest = latest_pypi_version()
+
+    if latest is None:
+        if not quiet:
+            print("[solvent upgrade] Could not reach PyPI — skipping version check.")
+        return {"current": current, "latest": None, "up_to_date": True, "error": True}
+
+    up_to_date = _parse_version(current) >= _parse_version(latest)
+
+    if not quiet:
+        if up_to_date:
+            print(f"solvent {current} is up to date.")
+        else:
+            print(f"solvent {current} → {latest} available.")
+            print(f"  Upgrade with:  pip install --upgrade solvent-agent")
+            print(f"  Or full extras: pip install --upgrade 'solvent-agent[all]'")
+
+    return {"current": current, "latest": latest, "up_to_date": up_to_date, "error": False}
+
+
+def main():
+    import argparse
+    import subprocess
+
+    p = argparse.ArgumentParser(
+        description="Check for solvent-agent upgrades on PyPI.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    p.add_argument(
+        "--check",
+        action="store_true",
+        help="exit 1 if a newer version is available (CI-friendly)",
+    )
+    p.add_argument(
+        "--install",
+        action="store_true",
+        help="run pip install --upgrade solvent-agent if a newer version is available",
+    )
+    p.add_argument(
+        "--json",
+        action="store_true",
+        dest="as_json",
+        help="output result as JSON",
+    )
+    args = p.parse_args()
+
+    result = check_upgrade(quiet=args.as_json)
+
+    if args.as_json:
+        print(json.dumps(result, indent=2))
+
+    if not result["up_to_date"] and args.install:
+        print(f"\nRunning: pip install --upgrade solvent-agent")
+        rc = subprocess.call([sys.executable, "-m", "pip", "install", "--upgrade", "solvent-agent"])
+        sys.exit(rc)
+
+    if args.check and not result["up_to_date"]:
+        sys.exit(1)
+
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_upgrade.py
+++ b/tests/test_upgrade.py
@@ -1,0 +1,160 @@
+"""tests/test_upgrade.py — unit tests for the upgrade version checker."""
+
+import io
+import json
+import sys
+import unittest
+from contextlib import redirect_stdout
+from unittest import mock
+
+from solvent.upgrade import _parse_version, check_upgrade, current_version
+
+
+class TestParseVersion(unittest.TestCase):
+
+    def test_simple_semver(self):
+        self.assertEqual(_parse_version("1.2.3"), (1, 2, 3))
+
+    def test_leading_v(self):
+        self.assertEqual(_parse_version("v2.0.0"), (2, 0, 0))
+
+    def test_two_part(self):
+        self.assertEqual(_parse_version("1.0"), (1, 0))
+
+    def test_non_numeric_segment(self):
+        result = _parse_version("1.2.alpha")
+        self.assertEqual(result[:2], (1, 2))
+
+    def test_newer_is_greater(self):
+        self.assertGreater(_parse_version("0.2.0"), _parse_version("0.1.9"))
+
+    def test_same_version_equal(self):
+        self.assertEqual(_parse_version("1.0.0"), _parse_version("1.0.0"))
+
+
+class TestCurrentVersion(unittest.TestCase):
+
+    def test_returns_string(self):
+        v = current_version()
+        self.assertIsInstance(v, str)
+        self.assertGreater(len(v), 0)
+
+    def test_looks_like_semver(self):
+        parts = current_version().split(".")
+        self.assertGreaterEqual(len(parts), 2)
+
+
+class TestCheckUpgrade(unittest.TestCase):
+
+    def _fake_pypi(self, version: str):
+        """Return a mock that simulates PyPI returning the given version."""
+        body = json.dumps({"info": {"version": version}}).encode()
+        resp = mock.MagicMock()
+        resp.read.return_value = body
+        resp.__enter__ = mock.MagicMock(return_value=resp)
+        resp.__exit__ = mock.MagicMock(return_value=False)
+        return mock.patch("urllib.request.urlopen", return_value=resp)
+
+    def test_up_to_date_when_same(self):
+        current = current_version()
+        with self._fake_pypi(current):
+            result = check_upgrade(quiet=True)
+        self.assertTrue(result["up_to_date"])
+        self.assertFalse(result["error"])
+
+    def test_outdated_when_newer_on_pypi(self):
+        with self._fake_pypi("99.0.0"):
+            result = check_upgrade(quiet=True)
+        self.assertFalse(result["up_to_date"])
+        self.assertEqual(result["latest"], "99.0.0")
+
+    def test_up_to_date_when_local_is_newer(self):
+        with self._fake_pypi("0.0.1"):
+            result = check_upgrade(quiet=True)
+        self.assertTrue(result["up_to_date"])
+
+    def test_network_error_treated_as_up_to_date(self):
+        import urllib.error
+        with mock.patch("urllib.request.urlopen", side_effect=urllib.error.URLError("offline")):
+            result = check_upgrade(quiet=True)
+        self.assertTrue(result["up_to_date"])
+        self.assertTrue(result["error"])
+        self.assertIsNone(result["latest"])
+
+    def test_prints_upgrade_hint_when_outdated(self):
+        buf = io.StringIO()
+        with self._fake_pypi("99.0.0"), redirect_stdout(buf):
+            check_upgrade(quiet=False)
+        out = buf.getvalue()
+        self.assertIn("99.0.0", out)
+        self.assertIn("pip install", out)
+
+    def test_prints_up_to_date_message(self):
+        buf = io.StringIO()
+        current = current_version()
+        with self._fake_pypi(current), redirect_stdout(buf):
+            check_upgrade(quiet=False)
+        self.assertIn("up to date", buf.getvalue())
+
+    def test_result_contains_current(self):
+        current = current_version()
+        with self._fake_pypi(current):
+            result = check_upgrade(quiet=True)
+        self.assertEqual(result["current"], current)
+
+
+class TestUpgradeCLI(unittest.TestCase):
+
+    def _fake_pypi(self, version: str):
+        body = json.dumps({"info": {"version": version}}).encode()
+        resp = mock.MagicMock()
+        resp.read.return_value = body
+        resp.__enter__ = mock.MagicMock(return_value=resp)
+        resp.__exit__ = mock.MagicMock(return_value=False)
+        return mock.patch("urllib.request.urlopen", return_value=resp)
+
+    def test_main_exits_zero_when_up_to_date(self):
+        from solvent.upgrade import main
+        current = current_version()
+        with self._fake_pypi(current), \
+             mock.patch.object(sys, "argv", ["solvent-upgrade"]), \
+             mock.patch("sys.stdout", new_callable=io.StringIO):
+            with self.assertRaises(SystemExit) as ctx:
+                main()
+        self.assertEqual(ctx.exception.code, 0)
+
+    def test_check_flag_exits_one_when_outdated(self):
+        from solvent.upgrade import main
+        with self._fake_pypi("99.0.0"), \
+             mock.patch.object(sys, "argv", ["solvent-upgrade", "--check"]), \
+             mock.patch("sys.stdout", new_callable=io.StringIO):
+            with self.assertRaises(SystemExit) as ctx:
+                main()
+        self.assertEqual(ctx.exception.code, 1)
+
+    def test_check_flag_exits_zero_when_current(self):
+        from solvent.upgrade import main
+        current = current_version()
+        with self._fake_pypi(current), \
+             mock.patch.object(sys, "argv", ["solvent-upgrade", "--check"]), \
+             mock.patch("sys.stdout", new_callable=io.StringIO):
+            with self.assertRaises(SystemExit) as ctx:
+                main()
+        self.assertEqual(ctx.exception.code, 0)
+
+    def test_json_flag_outputs_json(self):
+        from solvent.upgrade import main
+        current = current_version()
+        buf = io.StringIO()
+        with self._fake_pypi(current), \
+             mock.patch.object(sys, "argv", ["solvent-upgrade", "--json"]), \
+             redirect_stdout(buf):
+            with self.assertRaises(SystemExit):
+                main()
+        data = json.loads(buf.getvalue())
+        self.assertIn("current", data)
+        self.assertIn("up_to_date", data)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- New `solvent/upgrade.py`: checks PyPI for the latest `solvent-agent` release, pure stdlib (`urllib.request` + `json`), no optional extras needed
- `_parse_version()` compares `X.Y.Z` tuples without pulling in `packaging`
- Network errors are handled gracefully (treated as "up to date" with a warning)
- Wired into `__main__.py` as `solvent upgrade`

Flags:
- `--check` — exit 1 if outdated (CI-friendly; good in startup scripts / doctor checks)
- `--install` — run `pip install --upgrade solvent-agent` automatically
- `--json` — machine-readable output

## Test plan

- [ ] `python3 -m pytest tests/test_upgrade.py -v` → 19 passed
- [ ] `python3 -m pytest -q` → 311 passed, 6 skipped
- [ ] `solvent upgrade` prints "up to date" or version + pip hint
- [ ] `solvent upgrade --check` exits 1 when outdated
- [ ] `solvent upgrade --json` emits valid JSON

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SGjM79GJpSksy9wSSBa7e6

---
_Generated by [Claude Code](https://claude.ai/code/session_01SGjM79GJpSksy9wSSBa7e6)_