### PR TITLE
add: solvent status — live at-a-glance agent summary

### DIFF
--- a/solvent/__main__.py
+++ b/solvent/__main__.py
@@ -10,6 +10,7 @@ Usage: solvent <command> [options]
 
 Commands:
   (none)        run the batch demo / interactive session
+  status        live summary: balance, jobs, API key presence; --watch to auto-refresh
   serve         webhooks + job API + hosted briefs
   worker        resume incomplete jobs, process the queue
   telegram      long-poll the Telegram bot
@@ -40,7 +41,11 @@ def main():
     if len(sys.argv) > 1 and sys.argv[1] in ("help", "--help", "-h"):
         print(HELP)
         return
-    if len(sys.argv) > 1 and sys.argv[1] == "serve":
+    if len(sys.argv) > 1 and sys.argv[1] == "status":
+        sys.argv.pop(1)
+        from .status import main as status_main
+        status_main()
+    elif len(sys.argv) > 1 and sys.argv[1] == "serve":
         sys.argv.pop(1)
         from .server import main as serve_main
         serve_main()

--- a/solvent/status.py
+++ b/solvent/status.py
@@ -1,0 +1,191 @@
+"""
+status.py — quick at-a-glance summary of the SOLVENT agent's live state.
+
+Usage:
+    solvent status          human-readable summary
+    solvent status --json   machine-readable JSON
+    solvent status --watch  refresh every N seconds (default 5)
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import time
+from datetime import datetime, timezone
+from typing import Any
+
+
+_STATUS_LABELS = {
+    "completed": "done",
+    "failed": "failed",
+    "in_progress": "running",
+    "awaiting_payment": "awaiting payment",
+    "paid_pending_fulfill": "paid/fulfilling",
+}
+
+_MARK = {
+    "done": "✓",
+    "failed": "✗",
+    "running": "▶",
+    "awaiting payment": "…",
+    "paid/fulfilling": "▶",
+}
+
+
+def _fmt_cents(cents: int) -> str:
+    return f"${cents / 100:,.2f}"
+
+
+def _time_ago(ts: float) -> str:
+    """Return a human-readable 'N ago' string for a Unix timestamp."""
+    delta = time.time() - ts
+    if delta < 60:
+        return f"{int(delta)}s ago"
+    if delta < 3600:
+        return f"{int(delta / 60)}m ago"
+    if delta < 86400:
+        return f"{int(delta / 3600)}h ago"
+    return f"{int(delta / 86400)}d ago"
+
+
+def gather(treasury=None) -> dict[str, Any]:
+    """Collect all status data into a single dict."""
+    if treasury is None:
+        from .treasury import Treasury
+        treasury = Treasury()
+
+    snap = treasury.snapshot()
+    jobs = treasury.list_jobs()
+    events = treasury.list_events(limit=5)
+
+    # Count by status
+    status_counts: dict[str, int] = {}
+    for j in jobs:
+        s = j.get("status", "unknown")
+        status_counts[s] = status_counts.get(s, 0) + 1
+
+    # Most recent job
+    last_job = None
+    if jobs:
+        last_job = max(jobs, key=lambda j: j.get("updated_at") or j.get("created_at") or 0)
+
+    # Last event time
+    last_event_ts = events[0].get("ts") if events else None
+
+    # API key presence
+    keys = {
+        "nvidia": bool(os.environ.get("NVIDIA_API_KEY")),
+        "stripe": bool(os.environ.get("STRIPE_API_KEY")),
+        "telegram": bool(os.environ.get("TELEGRAM_BOT_TOKEN")),
+    }
+
+    return {
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+        "balance_cents": snap.get("balance_cents", 0),
+        "revenue_cents": snap.get("revenue_cents", 0),
+        "net_profit_cents": snap.get("net_profit_cents", 0),
+        "margin_pct": snap.get("margin_pct", 0.0),
+        "total_jobs": len(jobs),
+        "status_counts": status_counts,
+        "last_job": {
+            "id": last_job["id"],
+            "topic": (last_job.get("topic") or "")[:60],
+            "status": last_job.get("status", ""),
+            "updated_at": last_job.get("updated_at") or last_job.get("created_at"),
+        } if last_job else None,
+        "last_event_ts": last_event_ts,
+        "api_keys": keys,
+    }
+
+
+def format_status(data: dict) -> str:
+    lines = []
+    ts = data.get("timestamp", "")[:19].replace("T", " ")
+    lines.append(f"SOLVENT status  {ts} UTC")
+    lines.append("─" * 50)
+
+    # Treasury
+    bal = data["balance_cents"]
+    rev = data["revenue_cents"]
+    margin = data["margin_pct"]
+    lines.append(f"  Balance   {_fmt_cents(bal):>10}   Revenue {_fmt_cents(rev):>10}   Margin {margin:.1f}%")
+    lines.append("")
+
+    # Jobs
+    total = data["total_jobs"]
+    counts = data["status_counts"]
+    active = counts.get("in_progress", 0) + counts.get("paid_pending_fulfill", 0)
+    pending = counts.get("awaiting_payment", 0)
+    done = counts.get("completed", 0)
+    failed = counts.get("failed", 0)
+
+    lines.append(f"  Jobs      {total} total  •  {active} running  •  {pending} awaiting payment")
+    lines.append(f"            {done} completed  •  {failed} failed")
+
+    last = data.get("last_job")
+    if last:
+        ago = _time_ago(last["updated_at"]) if last.get("updated_at") else "?"
+        label = _STATUS_LABELS.get(last["status"], last["status"])
+        mark = _MARK.get(label, "·")
+        topic = last["topic"] or last["id"]
+        lines.append(f"  Last job  [{mark}] {topic[:45]}  ({ago})")
+
+    lines.append("")
+
+    # API keys
+    keys = data.get("api_keys", {})
+    key_parts = []
+    key_parts.append(f"nvidia {'✓' if keys.get('nvidia') else '✗'}")
+    key_parts.append(f"stripe {'✓' if keys.get('stripe') else '✗'}")
+    key_parts.append(f"telegram {'✓' if keys.get('telegram') else '✗'}")
+    lines.append(f"  API keys  {' · '.join(key_parts)}")
+
+    last_ev = data.get("last_event_ts")
+    if last_ev:
+        lines.append(f"  Activity  last event {_time_ago(float(last_ev))}")
+
+    return "\n".join(lines)
+
+
+def main():
+    import argparse
+
+    p = argparse.ArgumentParser(
+        description="Print a live summary of the SOLVENT agent state.",
+    )
+    p.add_argument("--json", action="store_true", dest="as_json", help="output as JSON")
+    p.add_argument(
+        "--watch",
+        nargs="?",
+        const=5,
+        type=float,
+        metavar="SECONDS",
+        help="refresh every N seconds (default 5)",
+    )
+    args = p.parse_args()
+
+    def _once():
+        data = gather()
+        if args.as_json:
+            print(json.dumps(data, indent=2, default=str))
+        else:
+            print(format_status(data))
+
+    if args.watch:
+        try:
+            while True:
+                if not args.as_json:
+                    # Clear screen for watch mode
+                    print("\033[2J\033[H", end="")
+                _once()
+                time.sleep(args.watch)
+        except KeyboardInterrupt:
+            pass
+    else:
+        _once()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_status.py
+++ b/tests/test_status.py
@@ -1,0 +1,193 @@
+"""tests/test_status.py — unit tests for solvent status command."""
+
+import io
+import json
+import os
+import sys
+import tempfile
+import time
+import unittest
+from contextlib import redirect_stdout
+from unittest import mock
+
+from solvent.status import gather, format_status, _time_ago, _fmt_cents
+
+
+class TestHelpers(unittest.TestCase):
+
+    def test_fmt_cents_whole_dollar(self):
+        self.assertEqual(_fmt_cents(100), "$1.00")
+
+    def test_fmt_cents_large(self):
+        self.assertEqual(_fmt_cents(123456), "$1,234.56")
+
+    def test_fmt_cents_zero(self):
+        self.assertEqual(_fmt_cents(0), "$0.00")
+
+    def test_time_ago_seconds(self):
+        result = _time_ago(time.time() - 30)
+        self.assertIn("s ago", result)
+
+    def test_time_ago_minutes(self):
+        result = _time_ago(time.time() - 120)
+        self.assertIn("m ago", result)
+
+    def test_time_ago_hours(self):
+        result = _time_ago(time.time() - 7200)
+        self.assertIn("h ago", result)
+
+    def test_time_ago_days(self):
+        result = _time_ago(time.time() - 172800)
+        self.assertIn("d ago", result)
+
+
+class TestGather(unittest.TestCase):
+
+    def _make_treasury(self):
+        from solvent.treasury import Treasury
+        return Treasury(path=f"/tmp/solvent_status_test_{id(self)}.db")
+
+    def test_gather_returns_dict(self):
+        t = self._make_treasury()
+        data = gather(treasury=t)
+        self.assertIsInstance(data, dict)
+
+    def test_gather_has_required_keys(self):
+        t = self._make_treasury()
+        data = gather(treasury=t)
+        for key in ("timestamp", "balance_cents", "revenue_cents", "total_jobs",
+                    "status_counts", "last_job", "api_keys"):
+            self.assertIn(key, data)
+
+    def test_gather_balance_is_int(self):
+        t = self._make_treasury()
+        data = gather(treasury=t)
+        self.assertIsInstance(data["balance_cents"], int)
+
+    def test_gather_total_jobs_zero_on_empty(self):
+        t = self._make_treasury()
+        data = gather(treasury=t)
+        self.assertEqual(data["total_jobs"], 0)
+        self.assertIsNone(data["last_job"])
+
+    def test_gather_api_keys_dict(self):
+        t = self._make_treasury()
+        with mock.patch.dict(os.environ, {"NVIDIA_API_KEY": "nvapi-test"}):
+            data = gather(treasury=t)
+        self.assertTrue(data["api_keys"]["nvidia"])
+        self.assertFalse(data["api_keys"]["stripe"])
+
+    def test_gather_counts_jobs_by_status(self):
+        t = self._make_treasury()
+        t.upsert_job("job_a", "awaiting_payment", topic="Topic A", budget_cents=1000)
+        t.upsert_job("job_b", "completed", topic="Topic B", budget_cents=2000)
+        data = gather(treasury=t)
+        self.assertEqual(data["total_jobs"], 2)
+        self.assertIn("awaiting_payment", data["status_counts"])
+        self.assertIn("completed", data["status_counts"])
+
+    def test_gather_last_job_present_after_create(self):
+        t = self._make_treasury()
+        t.upsert_job("job_x", "awaiting_payment", topic="Test topic", budget_cents=500)
+        data = gather(treasury=t)
+        self.assertIsNotNone(data["last_job"])
+        self.assertIn("Test topic", data["last_job"]["topic"])
+
+
+class TestFormatStatus(unittest.TestCase):
+
+    def _sample_data(self, **overrides) -> dict:
+        base = {
+            "timestamp": "2026-01-01T12:00:00+00:00",
+            "balance_cents": 5000,
+            "revenue_cents": 10000,
+            "net_profit_cents": 5000,
+            "margin_pct": 50.0,
+            "total_jobs": 3,
+            "status_counts": {"completed": 2, "awaiting_payment": 1},
+            "last_job": {
+                "id": "job_001",
+                "topic": "Nvidia earnings brief",
+                "status": "completed",
+                "updated_at": time.time() - 300,
+            },
+            "last_event_ts": time.time() - 60,
+            "api_keys": {"nvidia": True, "stripe": False, "telegram": False},
+        }
+        base.update(overrides)
+        return base
+
+    def test_format_contains_balance(self):
+        out = format_status(self._sample_data())
+        self.assertIn("$50.00", out)
+
+    def test_format_contains_revenue(self):
+        out = format_status(self._sample_data())
+        self.assertIn("$100.00", out)
+
+    def test_format_contains_margin(self):
+        out = format_status(self._sample_data())
+        self.assertIn("50.0%", out)
+
+    def test_format_contains_job_count(self):
+        out = format_status(self._sample_data())
+        self.assertIn("3 total", out)
+
+    def test_format_contains_last_job_topic(self):
+        out = format_status(self._sample_data())
+        self.assertIn("Nvidia earnings brief", out)
+
+    def test_format_shows_api_key_presence(self):
+        out = format_status(self._sample_data())
+        self.assertIn("nvidia ✓", out)
+        self.assertIn("stripe ✗", out)
+
+    def test_format_handles_no_jobs(self):
+        data = self._sample_data(total_jobs=0, status_counts={}, last_job=None)
+        out = format_status(data)
+        self.assertIn("0 total", out)
+
+    def test_format_handles_no_events(self):
+        data = self._sample_data(last_event_ts=None)
+        out = format_status(data)
+        self.assertIsInstance(out, str)
+
+
+class TestStatusCLI(unittest.TestCase):
+
+    def _make_treasury(self):
+        from solvent.treasury import Treasury
+        return Treasury(path=f"/tmp/solvent_status_cli_test_{id(self)}.db")
+
+    def test_json_output_is_valid(self):
+        from solvent.status import main
+        t = self._make_treasury()
+        buf = io.StringIO()
+        with mock.patch("solvent.status.gather", return_value={
+            "timestamp": "2026-01-01T00:00:00+00:00",
+            "balance_cents": 0, "revenue_cents": 0, "net_profit_cents": 0,
+            "margin_pct": 0.0, "total_jobs": 0, "status_counts": {},
+            "last_job": None, "last_event_ts": None, "api_keys": {},
+        }), mock.patch.object(sys, "argv", ["solvent-status", "--json"]), \
+             redirect_stdout(buf):
+            main()
+        data = json.loads(buf.getvalue())
+        self.assertIn("balance_cents", data)
+
+    def test_human_output_contains_status_header(self):
+        from solvent.status import main
+        buf = io.StringIO()
+        with mock.patch("solvent.status.gather", return_value={
+            "timestamp": "2026-01-01T00:00:00+00:00",
+            "balance_cents": 100, "revenue_cents": 200, "net_profit_cents": 100,
+            "margin_pct": 50.0, "total_jobs": 0, "status_counts": {},
+            "last_job": None, "last_event_ts": None,
+            "api_keys": {"nvidia": False, "stripe": False, "telegram": False},
+        }), mock.patch.object(sys, "argv", ["solvent-status"]), \
+             redirect_stdout(buf):
+            main()
+        self.assertIn("SOLVENT status", buf.getvalue())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- New `solvent/status.py`: prints a live snapshot of treasury balance, revenue, margin, job counts by status, last job topic/time, and API key presence
- `--watch N` auto-refreshes every N seconds (default 5) with screen-clear — replaces a poor-man's TUI when `rich` isn't installed
- `--json` for scripting / monitoring integrations
- Pure stdlib, works in the zero-dep core install
- Wired into `__main__.py` as `solvent status`

**Command triangle:**
- `solvent status` — quick operational snapshot (this PR)
- `solvent doctor` — deep install/stack diagnostics
- `solvent finance` — full income statement + runway forecast

## Test plan

- [ ] `python3 -m pytest tests/test_status.py -v` → 24 passed
- [ ] `python3 -m pytest -q` → 321 passed, 6 skipped
- [ ] `solvent status` prints balance, job counts, API key grid
- [ ] `solvent status --json` outputs valid JSON with `balance_cents`
- [ ] `solvent status --watch 2` refreshes and clears screen on Ctrl-C

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SGjM79GJpSksy9wSSBa7e6

---
_Generated by [Claude Code](https://claude.ai/code/session_01SGjM79GJpSksy9wSSBa7e6)_