### PR TITLE
test: add coverage for EventHub and observability.log_event

### DIFF
--- a/tests/test_event_hub.py
+++ b/tests/test_event_hub.py
@@ -1,0 +1,148 @@
+"""Tests for solvent/event_hub.py."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import threading
+
+import pytest
+
+from solvent.event_hub import EventHub
+
+
+# ---------------------------------------------------------------------------
+# subscribe / unsubscribe
+# ---------------------------------------------------------------------------
+
+def test_subscribe_returns_queue():
+    hub = EventHub()
+    q = hub.subscribe()
+    assert isinstance(q, asyncio.Queue)
+    assert len(hub._queues) == 1
+
+
+def test_unsubscribe_removes_queue():
+    hub = EventHub()
+    q = hub.subscribe()
+    hub.unsubscribe(q)
+    assert q not in hub._queues
+
+
+def test_unsubscribe_unknown_queue_is_noop():
+    hub = EventHub()
+    q = asyncio.Queue()
+    hub.unsubscribe(q)  # should not raise
+
+
+def test_multiple_subscribers():
+    hub = EventHub()
+    q1 = hub.subscribe()
+    q2 = hub.subscribe()
+    assert len(hub._queues) == 2
+    hub.unsubscribe(q1)
+    assert len(hub._queues) == 1
+    assert q2 in hub._queues
+
+
+# ---------------------------------------------------------------------------
+# publish (no event loop — put_nowait path)
+# ---------------------------------------------------------------------------
+
+def test_publish_delivers_to_subscriber():
+    hub = EventHub()
+    q = hub.subscribe()
+    hub.publish("test_event", {"key": "value"})
+    msg = q.get_nowait()
+    assert msg["type"] == "test_event"
+    assert msg["key"] == "value"
+
+
+def test_publish_fans_out_to_all_subscribers():
+    hub = EventHub()
+    q1 = hub.subscribe()
+    q2 = hub.subscribe()
+    hub.publish("ping")
+    assert q1.get_nowait()["type"] == "ping"
+    assert q2.get_nowait()["type"] == "ping"
+
+
+def test_publish_no_subscribers_is_noop():
+    hub = EventHub()
+    hub.publish("orphan")  # should not raise
+
+
+def test_publish_none_payload():
+    hub = EventHub()
+    q = hub.subscribe()
+    hub.publish("empty")
+    msg = q.get_nowait()
+    assert msg == {"type": "empty"}
+
+
+def test_publish_queue_full_drops_message():
+    hub = EventHub()
+    q = asyncio.Queue(maxsize=1)
+    with hub._lock:
+        hub._queues.append(q)
+    hub.publish("first")
+    hub.publish("second")  # should not raise even when queue is full
+    assert q.qsize() == 1
+    assert q.get_nowait()["type"] == "first"
+
+
+def test_publish_after_unsubscribe_not_delivered():
+    hub = EventHub()
+    q = hub.subscribe()
+    hub.unsubscribe(q)
+    hub.publish("ghost")
+    assert q.empty()
+
+
+# ---------------------------------------------------------------------------
+# publish with running event loop (call_soon_threadsafe path)
+# ---------------------------------------------------------------------------
+
+def test_publish_via_loop_threadsafe():
+    hub = EventHub()
+    results: list[dict] = []
+
+    async def _runner():
+        q = hub.subscribe()
+        hub.bind_loop(asyncio.get_event_loop())
+
+        def _publish():
+            hub.publish("async_event", {"x": 1})
+
+        t = threading.Thread(target=_publish)
+        t.start()
+        t.join()
+        await asyncio.sleep(0)  # let call_soon_threadsafe callbacks drain
+        results.append(q.get_nowait())
+
+    asyncio.run(_runner())
+    assert results[0]["type"] == "async_event"
+    assert results[0]["x"] == 1
+
+
+# ---------------------------------------------------------------------------
+# sse_format
+# ---------------------------------------------------------------------------
+
+def test_sse_format():
+    data = {"type": "tick", "balance": 100}
+    result = EventHub.sse_format(data)
+    assert result.startswith("data: ")
+    assert result.endswith("\n\n")
+    parsed = json.loads(result[len("data: "):].strip())
+    assert parsed == data
+
+
+def test_sse_format_is_valid_json():
+    hub = EventHub()
+    q = hub.subscribe()
+    hub.publish("metric", {"cents": 9999})
+    msg = q.get_nowait()
+    sse = EventHub.sse_format(msg)
+    parsed = json.loads(sse[len("data: "):].strip())
+    assert parsed["cents"] == 9999

--- a/tests/test_observability.py
+++ b/tests/test_observability.py
@@ -1,0 +1,147 @@
+"""Tests for solvent/observability.py."""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from unittest import mock
+
+import pytest
+
+from solvent.observability import log_event
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _log_event(tmp_path: Path, treasury=None, **kwargs) -> dict:
+    log_path = tmp_path / "solvent.log"
+    with mock.patch("solvent.observability.LOG_PATH", log_path):
+        return log_event(treasury, **kwargs)
+
+
+# ---------------------------------------------------------------------------
+# Return value
+# ---------------------------------------------------------------------------
+
+def test_log_event_returns_dict(tmp_path):
+    rec = _log_event(tmp_path, job_id="j1", stage="start")
+    assert isinstance(rec, dict)
+    assert rec["job_id"] == "j1"
+    assert rec["stage"] == "start"
+    assert "ts" in rec
+
+
+def test_log_event_includes_extra_fields(tmp_path):
+    rec = _log_event(tmp_path, job_id="j2", stage="fulfill", custom="hello")
+    assert rec["custom"] == "hello"
+
+
+def test_log_event_filters_none_values(tmp_path):
+    rec = _log_event(tmp_path, job_id="j3", stage="s", stripe_ref=None, margin_est=None)
+    assert "stripe_ref" not in rec
+    assert "margin_est" not in rec
+
+
+def test_log_event_includes_optional_fields_when_set(tmp_path):
+    rec = _log_event(
+        tmp_path,
+        job_id="j4",
+        stage="quote",
+        stripe_ref="pi_123",
+        margin_est=0.42,
+        duration_ms=123.4,
+        simulated=True,
+    )
+    assert rec["stripe_ref"] == "pi_123"
+    assert rec["margin_est"] == pytest.approx(0.42)
+    assert rec["duration_ms"] == pytest.approx(123.4)
+    assert rec["simulated"] is True
+
+
+# ---------------------------------------------------------------------------
+# File output
+# ---------------------------------------------------------------------------
+
+def test_log_event_writes_to_log_file(tmp_path):
+    _log_event(tmp_path, job_id="j5", stage="write_test")
+    log_path = tmp_path / "solvent.log"
+    assert log_path.exists()
+    line = log_path.read_text(encoding="utf-8").strip()
+    data = json.loads(line)
+    assert data["job_id"] == "j5"
+
+
+def test_log_event_appends_multiple_lines(tmp_path):
+    _log_event(tmp_path, job_id="j6", stage="a")
+    _log_event(tmp_path, job_id="j6", stage="b")
+    log_path = tmp_path / "solvent.log"
+    lines = log_path.read_text(encoding="utf-8").strip().splitlines()
+    assert len(lines) == 2
+    assert json.loads(lines[0])["stage"] == "a"
+    assert json.loads(lines[1])["stage"] == "b"
+
+
+def test_log_event_creates_parent_dirs(tmp_path):
+    nested = tmp_path / "deep" / "dir" / "solvent.log"
+    with mock.patch("solvent.observability.LOG_PATH", nested):
+        log_event(None, job_id="j7", stage="mkdir_test")
+    assert nested.exists()
+
+
+def test_log_event_survives_oserror(tmp_path, monkeypatch):
+    log_path = tmp_path / "solvent.log"
+
+    def _bad_open(*a, **kw):
+        raise OSError("disk full")
+
+    with mock.patch("solvent.observability.LOG_PATH", log_path):
+        with mock.patch("builtins.open", _bad_open):
+            rec = log_event(None, job_id="j8", stage="error_test")
+    assert rec["job_id"] == "j8"
+
+
+# ---------------------------------------------------------------------------
+# Treasury interaction
+# ---------------------------------------------------------------------------
+
+def test_log_event_calls_treasury_record_event(tmp_path):
+    t = mock.MagicMock()
+    _log_event(tmp_path, treasury=t, job_id="j9", stage="record_test")
+    t.record_event.assert_called_once()
+    args = t.record_event.call_args[0]
+    assert args[0] == "j9"
+    assert args[1] == "record_test"
+
+
+def test_log_event_skips_treasury_on_none(tmp_path):
+    rec = _log_event(tmp_path, treasury=None, job_id="j10", stage="no_treasury")
+    assert rec["job_id"] == "j10"
+
+
+def test_log_event_survives_treasury_exception(tmp_path):
+    t = mock.MagicMock()
+    t.record_event.side_effect = RuntimeError("db gone")
+    rec = _log_event(tmp_path, treasury=t, job_id="j11", stage="exception_test")
+    assert rec["job_id"] == "j11"
+
+
+# ---------------------------------------------------------------------------
+# stderr JSON logging (SOLVENT_LOG_JSON)
+# ---------------------------------------------------------------------------
+
+def test_log_event_prints_to_stderr_when_env_set(tmp_path, capsys):
+    with mock.patch.dict(os.environ, {"SOLVENT_LOG_JSON": "1"}):
+        _log_event(tmp_path, job_id="j12", stage="stderr_test")
+    err = capsys.readouterr().err
+    data = json.loads(err.strip())
+    assert data["job_id"] == "j12"
+
+
+def test_log_event_no_stderr_by_default(tmp_path, capsys):
+    env = {k: v for k, v in os.environ.items() if k != "SOLVENT_LOG_JSON"}
+    with mock.patch.dict(os.environ, env, clear=True):
+        _log_event(tmp_path, job_id="j13", stage="quiet_test")
+    assert capsys.readouterr().err == ""


### PR DESCRIPTION
## Summary

- Adds 13 tests for `EventHub` in `tests/test_event_hub.py`: subscribe/unsubscribe lifecycle, multi-subscriber fan-out, queue-full drop behaviour, thread-safe publish via a running asyncio event loop, and SSE wire format
- Adds 13 tests for `observability.log_event` in `tests/test_observability.py`: return-value shape, None-field filtering, optional-field inclusion, file write/append/mkdir-on-demand, OSError resilience, treasury `record_event` integration, and `SOLVENT_LOG_JSON` stderr output

Both modules were previously untested in CI.

## Test plan

- [ ] 26 new tests all pass locally (276 total, 6 skipped, 0 failures)
- [ ] No changes to production code — pure test additions

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SGjM79GJpSksy9wSSBa7e6

---
_Generated by [Claude Code](https://claude.ai/code/session_01SGjM79GJpSksy9wSSBa7e6)_