### PR TITLE
add: solvent events — structured per-job stage events from the treasury DB

### DIFF
--- a/solvent/__main__.py
+++ b/solvent/__main__.py
@@ -56,6 +56,10 @@ def main():
         sys.argv.pop(1)
         from .metrics_cmd import main as metrics_main
         metrics_main()
+    elif len(sys.argv) > 1 and sys.argv[1] == "events":
+        sys.argv.pop(1)
+        from .solvent/events_cmd import main as events_main
+        events_main()
     elif len(sys.argv) > 1 and sys.argv[1] == "rate-limit":
         sys.argv.pop(1)
         from .solvent/rate_limit_cmd import main as rate_limit_main

--- a/solvent/events_cmd.py
+++ b/solvent/events_cmd.py
@@ -1,0 +1,116 @@
+"""
+events.py — structured per-job stage events from the SOLVENT treasury DB.
+
+Complements `solvent logs` (which reads the append-only log file) with a
+queryable view of events persisted to SQLite via observability.log_event.
+
+Usage:
+    solvent events                        show last 20 events
+    solvent events -n 50                  show last 50 events
+    solvent events --job <id>             filter to a specific job (prefix match)
+    solvent events --stage <stage>        filter by stage name
+    solvent events --json                 output raw JSON
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from datetime import datetime, timezone
+from typing import Optional
+
+
+def _fmt_ts(ts: float) -> str:
+    dt = datetime.fromtimestamp(ts, tz=timezone.utc).astimezone()
+    return dt.strftime("%Y-%m-%d %H:%M:%S")
+
+
+def _human_line(ev: dict) -> str:
+    ts = _fmt_ts(ev["ts"])
+    job = f"[{ev['job_id'][:8]}]" if ev.get("job_id") else "[        ]"
+    stage = (ev.get("stage") or "")[:20]
+    payload = ev.get("payload_json") or "{}"
+    try:
+        data = json.loads(payload)
+    except Exception:
+        data = {}
+    extras = []
+    if data.get("stripe_ref"):
+        extras.append(f"stripe={data['stripe_ref']}")
+    if data.get("margin_actual") is not None:
+        extras.append(f"margin={data['margin_actual']:.0%}")
+    if data.get("duration_ms") is not None:
+        extras.append(f"{data['duration_ms']:.0f}ms")
+    if data.get("simulated"):
+        extras.append("sim")
+    suffix = "  " + "  ".join(extras) if extras else ""
+    return f"{ts}  {job}  {stage:<20}{suffix}"
+
+
+def show_events(
+    treasury=None,
+    *,
+    n: int = 20,
+    job: Optional[str] = None,
+    stage: Optional[str] = None,
+    as_json: bool = False,
+) -> None:
+    if treasury is None:
+        from .treasury import Treasury
+        treasury = Treasury()
+
+    raw = treasury.list_events(job_id=job if (job and len(job) >= 8) else None, limit=max(n * 5, 500))
+
+    # Apply prefix filter (treasury only does exact job_id match)
+    if job:
+        raw = [e for e in raw if e.get("job_id") and e["job_id"].startswith(job)]
+
+    if stage:
+        raw = [e for e in raw if e.get("stage") == stage]
+
+    events = raw[:n]
+
+    if not events:
+        print("(no events)")
+        return
+
+    if as_json:
+        out = []
+        for ev in events:
+            row = dict(ev)
+            raw_payload = row.pop("payload_json", None)
+            try:
+                row["payload"] = json.loads(raw_payload) if raw_payload else {}
+            except Exception:
+                row["payload"] = {}
+            out.append(row)
+        print(json.dumps(out, indent=2, default=str))
+        return
+
+    print(f"  {len(events)} event(s) shown (newest first)\n")
+    for ev in events:
+        print(_human_line(ev))
+
+
+def main() -> None:
+    import argparse
+
+    p = argparse.ArgumentParser(
+        description="Show structured per-job stage events (newest first).",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    p.add_argument("-n", "--lines", type=int, default=20, metavar="N",
+                   help="number of events to show (default 20)")
+    p.add_argument("--job", metavar="ID",
+                   help="filter to a specific job ID (prefix match)")
+    p.add_argument("--stage", metavar="STAGE",
+                   help="filter by stage name (e.g. quote, fulfill, charge)")
+    p.add_argument("--json", dest="as_json", action="store_true",
+                   help="output raw JSON")
+    args = p.parse_args()
+
+    show_events(n=args.lines, job=args.job, stage=args.stage, as_json=args.as_json)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -1,0 +1,202 @@
+"""Tests for solvent/events.py."""
+
+from __future__ import annotations
+
+import json
+import sys
+from io import StringIO
+from pathlib import Path
+from unittest import mock
+
+import pytest
+
+from solvent.events_cmd import _fmt_ts, _human_line, show_events
+from solvent.treasury import Treasury
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_treasury(tmp_path: Path) -> Treasury:
+    return Treasury(path=tmp_path / "solvent.db")
+
+
+def _record(t: Treasury, job_id: str, stage: str, **payload) -> None:
+    t.record_event(job_id, stage, {"job_id": job_id, "stage": stage, **payload})
+
+
+def _capture(treasury, **kwargs) -> str:
+    buf = StringIO()
+    with mock.patch("sys.stdout", buf):
+        show_events(treasury, **kwargs)
+    return buf.getvalue()
+
+
+# ---------------------------------------------------------------------------
+# _fmt_ts
+# ---------------------------------------------------------------------------
+
+def test_fmt_ts_has_date_and_time():
+    import time
+    result = _fmt_ts(time.time())
+    assert "-" in result and ":" in result
+
+
+# ---------------------------------------------------------------------------
+# _human_line
+# ---------------------------------------------------------------------------
+
+def test_human_line_basic():
+    ev = {
+        "id": "abc",
+        "job_id": "job123456789",
+        "stage": "fulfill",
+        "payload_json": "{}",
+        "ts": 1_700_000_000.0,
+    }
+    line = _human_line(ev)
+    assert "job1234" in line
+    assert "fulfill" in line
+
+
+def test_human_line_with_stripe_ref():
+    ev = {
+        "id": "x",
+        "job_id": "jjjjjjjjjjjj",
+        "stage": "charge",
+        "payload_json": json.dumps({"stripe_ref": "pi_abc"}),
+        "ts": 1_700_000_000.0,
+    }
+    line = _human_line(ev)
+    assert "stripe=pi_abc" in line
+
+
+def test_human_line_with_duration():
+    ev = {
+        "id": "y",
+        "job_id": "job000000000",
+        "stage": "fulfill",
+        "payload_json": json.dumps({"duration_ms": 1234.5}),
+        "ts": 1_700_000_000.0,
+    }
+    line = _human_line(ev)
+    assert "1235ms" in line or "1234ms" in line
+
+
+def test_human_line_simulated():
+    ev = {
+        "id": "z",
+        "job_id": "job000000000",
+        "stage": "quote",
+        "payload_json": json.dumps({"simulated": True}),
+        "ts": 1_700_000_000.0,
+    }
+    assert "sim" in _human_line(ev)
+
+
+def test_human_line_no_job_id():
+    ev = {"id": "n", "job_id": None, "stage": "boot", "payload_json": "{}", "ts": 1_700_000_000.0}
+    line = _human_line(ev)
+    assert "boot" in line
+
+
+# ---------------------------------------------------------------------------
+# show_events
+# ---------------------------------------------------------------------------
+
+def test_show_events_empty(tmp_path):
+    t = _make_treasury(tmp_path)
+    out = _capture(t)
+    assert "no events" in out.lower()
+
+
+def test_show_events_shows_entries(tmp_path):
+    t = _make_treasury(tmp_path)
+    _record(t, "job-aaa", "quote")
+    _record(t, "job-aaa", "fulfill")
+    out = _capture(t, n=10)
+    assert "quote" in out or "fulfill" in out
+
+
+def test_show_events_newest_first(tmp_path):
+    t = _make_treasury(tmp_path)
+    _record(t, "jobA", "stage-first")
+    _record(t, "jobA", "stage-second")
+    out = _capture(t, n=10)
+    assert out.index("stage-second") < out.index("stage-first")
+
+
+def test_show_events_filter_stage(tmp_path):
+    t = _make_treasury(tmp_path)
+    _record(t, "job1", "quote")
+    _record(t, "job2", "fulfill")
+    out = _capture(t, n=10, stage="quote")
+    assert "quote" in out
+    assert "fulfill" not in out
+
+
+def test_show_events_filter_job_prefix(tmp_path):
+    t = _make_treasury(tmp_path)
+    _record(t, "aaa-111", "quote")
+    _record(t, "bbb-222", "fulfill")
+    out = _capture(t, n=10, job="aaa")
+    assert "aaa" in out
+    assert "bbb" not in out
+
+
+def test_show_events_limit_n(tmp_path):
+    t = _make_treasury(tmp_path)
+    for i in range(10):
+        _record(t, f"job{i:04d}00", f"stage-{i}")
+    out = _capture(t, n=3)
+    count = sum(1 for line in out.splitlines() if "stage-" in line)
+    assert count == 3
+
+
+def test_show_events_json_mode(tmp_path):
+    t = _make_treasury(tmp_path)
+    _record(t, "job-json-1", "quote", ts=1.0)
+    out = _capture(t, n=5, as_json=True)
+    data = json.loads(out)
+    assert isinstance(data, list)
+    assert data[0]["job_id"] == "job-json-1"
+    assert "payload" in data[0]
+    assert "payload_json" not in data[0]
+
+
+def test_show_events_json_payload_is_dict(tmp_path):
+    t = _make_treasury(tmp_path)
+    _record(t, "job-json-2", "fulfill", duration_ms=500.0)
+    out = _capture(t, n=5, as_json=True)
+    data = json.loads(out)
+    assert isinstance(data[0]["payload"], dict)
+
+
+# ---------------------------------------------------------------------------
+# CLI main dispatch
+# ---------------------------------------------------------------------------
+
+def test_main_runs(tmp_path):
+    t = _make_treasury(tmp_path)
+    _record(t, "job-cli", "quote")
+    with mock.patch("sys.argv", ["solvent"]):
+        buf = StringIO()
+        with mock.patch("sys.stdout", buf):
+            with mock.patch("solvent.treasury.Treasury", return_value=t):
+                from solvent.events_cmd import main
+                main()
+    assert "event" in buf.getvalue().lower() or "quote" in buf.getvalue()
+
+
+def test_main_json_flag(tmp_path):
+    t = _make_treasury(tmp_path)
+    _record(t, "job-cli-json", "fulfill")
+    with mock.patch("sys.argv", ["solvent", "--json"]):
+        buf = StringIO()
+        with mock.patch("sys.stdout", buf):
+            with mock.patch("solvent.treasury.Treasury", return_value=t):
+                from solvent.events_cmd import main
+                main()
+    data = json.loads(buf.getvalue())
+    assert data[0]["job_id"] == "job-cli-json"


### PR DESCRIPTION
## Summary

- Adds `solvent events` CLI command (`solvent/events_cmd.py`) that reads per-job stage events from the treasury SQLite `events` table (written by `observability.log_event`)
- Supports `-n N`, `--job <prefix>`, `--stage <stage>`, and `--json` flags
- Human-readable lines surface stage name, job ID prefix, Stripe ref, duration, margin, and simulated flag when present in the payload
- JSON mode decodes `payload_json` to a dict and strips the raw column from output
- Renamed from `events.py` → `events_cmd.py` to avoid collision with the gitignored runtime artifact `solvent/events.py`

## Test plan

- [ ] 16 new tests in `tests/test_events.py` covering formatting helpers, all filter combinations, JSON mode, limit-n, and CLI dispatch
- [ ] 266 total tests pass (6 skipped, 0 regressions)
- [ ] `solvent events` shows newest events first with stage and job prefix
- [ ] `solvent events --stage fulfill` filters correctly
- [ ] `solvent events --job abc123 --json` emits a JSON array with decoded `payload` dict

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SGjM79GJpSksy9wSSBa7e6

---
_Generated by [Claude Code](https://claude.ai/code/session_01SGjM79GJpSksy9wSSBa7e6)_