### PR TITLE
add: solvent sessions — list and inspect chat session history

### DIFF
--- a/solvent/__main__.py
+++ b/solvent/__main__.py
@@ -56,6 +56,10 @@ def main():
         sys.argv.pop(1)
         from .metrics_cmd import main as metrics_main
         metrics_main()
+    elif len(sys.argv) > 1 and sys.argv[1] == "sessions":
+        sys.argv.pop(1)
+        from .solvent/sessions_cmd import main as sessions_main
+        sessions_main()
     elif len(sys.argv) > 1 and sys.argv[1] == "events":
         sys.argv.pop(1)
         from .solvent/events_cmd import main as events_main

--- a/solvent/sessions_cmd.py
+++ b/solvent/sessions_cmd.py
@@ -1,0 +1,134 @@
+"""
+sessions_cmd.py — CLI for viewing SOLVENT chat session history.
+
+Shows all chat sessions stored in the treasury DB, with optional filtering
+by channel and the ability to print the message history for a single session.
+
+Usage:
+    solvent sessions                        list recent sessions (all channels)
+    solvent sessions --channel telegram     filter by channel
+    solvent sessions --show <session_id>    print message history
+    solvent sessions --json                 output raw JSON
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from datetime import datetime, timezone
+from typing import Optional
+
+
+def _fmt_ts(ts: float) -> str:
+    dt = datetime.fromtimestamp(ts, tz=timezone.utc).astimezone()
+    return dt.strftime("%Y-%m-%d %H:%M")
+
+
+def _list_all_sessions(treasury, channel: Optional[str], limit: int) -> list[dict]:
+    """Return sessions across all channels, or filtered to one channel."""
+    with treasury.lock():
+        with treasury._conn() as conn:
+            if channel:
+                rows = conn.execute(
+                    "SELECT * FROM chat_sessions WHERE channel = ? "
+                    "ORDER BY updated_at DESC LIMIT ?",
+                    (channel, limit),
+                ).fetchall()
+            else:
+                rows = conn.execute(
+                    "SELECT * FROM chat_sessions ORDER BY updated_at DESC LIMIT ?",
+                    (limit,),
+                ).fetchall()
+    return [dict(r) for r in rows]
+
+
+def show_sessions(
+    treasury=None,
+    *,
+    n: int = 20,
+    channel: Optional[str] = None,
+    show_id: Optional[str] = None,
+    as_json: bool = False,
+) -> None:
+    if treasury is None:
+        from .treasury import Treasury
+        treasury = Treasury()
+
+    # Show single session with full message history
+    if show_id:
+        session = treasury.get_chat_session(show_id)
+        if not session:
+            print(f"(session {show_id!r} not found)")
+            return
+        messages = treasury.get_chat_messages(show_id, limit=200)
+        if as_json:
+            print(json.dumps({"session": session, "messages": messages}, indent=2, default=str))
+            return
+        label = session.get("user_label") or session.get("external_id", "?")
+        print(f"Session {show_id}  [{session['channel']}]  {label}")
+        print(f"Created {_fmt_ts(session['created_at'])}  "
+              f"Updated {_fmt_ts(session['updated_at'])}\n")
+        if not messages:
+            print("  (no messages)")
+        for msg in messages:
+            role = msg["role"].upper()
+            ts = _fmt_ts(msg["ts"])
+            content = (msg["content"] or "")[:120]
+            if len(msg.get("content", "")) > 120:
+                content += "…"
+            print(f"  {ts}  {role:<9} {content}")
+        return
+
+    sessions = _list_all_sessions(treasury, channel, limit=n)
+
+    if not sessions:
+        print("(no chat sessions)")
+        return
+
+    if as_json:
+        print(json.dumps(sessions, indent=2, default=str))
+        return
+
+    print(f"  {'ID':<32}  {'Channel':<10}  {'User':<20}  {'Updated':<16}  Msgs")
+    print("  " + "-" * 88)
+    for s in sessions:
+        sid = s.get("id", "")[:32]
+        ch = (s.get("channel") or "")[:10]
+        user = (s.get("user_label") or s.get("external_id") or "")[:20]
+        updated = _fmt_ts(s.get("updated_at", 0))
+        # Count messages efficiently
+        with treasury.lock():
+            with treasury._conn() as conn:
+                count = conn.execute(
+                    "SELECT COUNT(*) FROM chat_messages WHERE session_id = ?", (s["id"],)
+                ).fetchone()[0]
+        print(f"  {sid:<32}  {ch:<10}  {user:<20}  {updated:<16}  {count}")
+
+
+def main() -> None:
+    import argparse
+
+    p = argparse.ArgumentParser(
+        description="View SOLVENT chat session history.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    p.add_argument("-n", "--lines", type=int, default=20, metavar="N",
+                   help="number of sessions to show (default 20)")
+    p.add_argument("--channel", metavar="CHANNEL",
+                   help="filter by channel (telegram, web, …)")
+    p.add_argument("--show", metavar="SESSION_ID", dest="show_id",
+                   help="print full message history for a session")
+    p.add_argument("--json", dest="as_json", action="store_true",
+                   help="output raw JSON")
+    args = p.parse_args()
+
+    show_sessions(
+        n=args.lines,
+        channel=args.channel,
+        show_id=args.show_id,
+        as_json=args.as_json,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_sessions_cmd.py
+++ b/tests/test_sessions_cmd.py
@@ -1,0 +1,186 @@
+"""Tests for solvent/sessions_cmd.py."""
+
+from __future__ import annotations
+
+import json
+from io import StringIO
+from pathlib import Path
+from unittest import mock
+
+import pytest
+
+from solvent.sessions_cmd import show_sessions
+from solvent.treasury import Treasury
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_treasury(tmp_path: Path) -> Treasury:
+    return Treasury(path=tmp_path / "solvent.db")
+
+
+def _capture(treasury, **kwargs) -> str:
+    buf = StringIO()
+    with mock.patch("sys.stdout", buf):
+        show_sessions(treasury, **kwargs)
+    return buf.getvalue()
+
+
+def _add_session(t: Treasury, channel: str, ext_id: str, label: str | None = None) -> dict:
+    return t.get_or_create_chat_session(channel, ext_id, user_label=label)
+
+
+def _add_message(t: Treasury, session_id: str, role: str, content: str) -> None:
+    t.add_chat_message(session_id, role, content)
+
+
+# ---------------------------------------------------------------------------
+# show_sessions — list view
+# ---------------------------------------------------------------------------
+
+def test_empty_shows_no_sessions(tmp_path):
+    t = _make_treasury(tmp_path)
+    out = _capture(t)
+    assert "no chat sessions" in out.lower()
+
+
+def test_lists_created_session(tmp_path):
+    t = _make_treasury(tmp_path)
+    _add_session(t, "telegram", "user123", "Alice")
+    out = _capture(t)
+    assert "telegram" in out
+    assert "Alice" in out
+
+
+def test_multiple_sessions_shown(tmp_path):
+    t = _make_treasury(tmp_path)
+    _add_session(t, "telegram", "user1", "Alice")
+    _add_session(t, "web", "user2", "Bob")
+    out = _capture(t, n=10)
+    assert "Alice" in out
+    assert "Bob" in out
+
+
+def test_filter_by_channel(tmp_path):
+    t = _make_treasury(tmp_path)
+    _add_session(t, "telegram", "u1", "Alice")
+    _add_session(t, "web", "u2", "Bob")
+    out = _capture(t, n=10, channel="telegram")
+    assert "Alice" in out
+    assert "Bob" not in out
+
+
+def test_message_count_shown(tmp_path):
+    t = _make_treasury(tmp_path)
+    s = _add_session(t, "telegram", "user1")
+    _add_message(t, s["id"], "user", "hello")
+    _add_message(t, s["id"], "assistant", "hi")
+    out = _capture(t, n=10)
+    assert "2" in out
+
+
+def test_shows_external_id_when_no_label(tmp_path):
+    t = _make_treasury(tmp_path)
+    _add_session(t, "telegram", "ext999")
+    out = _capture(t)
+    assert "ext999" in out
+
+
+def test_limit_n(tmp_path):
+    t = _make_treasury(tmp_path)
+    for i in range(5):
+        _add_session(t, "telegram", f"user{i}", f"User{i}")
+    out = _capture(t, n=3)
+    count = sum(1 for line in out.splitlines() if "telegram" in line)
+    assert count == 3
+
+
+def test_list_json(tmp_path):
+    t = _make_treasury(tmp_path)
+    _add_session(t, "telegram", "u1", "Alice")
+    out = _capture(t, n=10, as_json=True)
+    data = json.loads(out)
+    assert isinstance(data, list)
+    assert data[0]["channel"] == "telegram"
+
+
+# ---------------------------------------------------------------------------
+# show_sessions — single session detail (--show)
+# ---------------------------------------------------------------------------
+
+def test_show_session_messages(tmp_path):
+    t = _make_treasury(tmp_path)
+    s = _add_session(t, "telegram", "user42", "Alice")
+    _add_message(t, s["id"], "user", "Hello agent!")
+    _add_message(t, s["id"], "assistant", "Hello Alice!")
+    out = _capture(t, show_id=s["id"])
+    assert "Hello agent!" in out
+    assert "Hello Alice!" in out
+    assert "USER" in out
+    assert "ASSISTANT" in out
+
+
+def test_show_session_not_found(tmp_path):
+    t = _make_treasury(tmp_path)
+    out = _capture(t, show_id="nonexistent:id")
+    assert "not found" in out.lower()
+
+
+def test_show_session_no_messages(tmp_path):
+    t = _make_treasury(tmp_path)
+    s = _add_session(t, "web", "anon1")
+    out = _capture(t, show_id=s["id"])
+    assert "no messages" in out.lower()
+
+
+def test_show_session_json(tmp_path):
+    t = _make_treasury(tmp_path)
+    s = _add_session(t, "telegram", "u99", "Bob")
+    _add_message(t, s["id"], "user", "test message")
+    out = _capture(t, show_id=s["id"], as_json=True)
+    data = json.loads(out)
+    assert "session" in data
+    assert "messages" in data
+    assert data["session"]["channel"] == "telegram"
+    assert data["messages"][0]["content"] == "test message"
+
+
+def test_show_session_truncates_long_content(tmp_path):
+    t = _make_treasury(tmp_path)
+    s = _add_session(t, "web", "user1")
+    _add_message(t, s["id"], "user", "x" * 200)
+    out = _capture(t, show_id=s["id"])
+    # Should be truncated, not full 200 chars shown as one chunk
+    assert "x" * 121 not in out
+    assert "…" in out
+
+
+# ---------------------------------------------------------------------------
+# CLI main dispatch
+# ---------------------------------------------------------------------------
+
+def test_main_runs(tmp_path):
+    t = _make_treasury(tmp_path)
+    _add_session(t, "telegram", "cli_user", "CLI User")
+    with mock.patch("sys.argv", ["solvent"]):
+        buf = StringIO()
+        with mock.patch("sys.stdout", buf):
+            with mock.patch("solvent.treasury.Treasury", return_value=t):
+                from solvent.sessions_cmd import main
+                main()
+    assert "telegram" in buf.getvalue()
+
+
+def test_main_json(tmp_path):
+    t = _make_treasury(tmp_path)
+    _add_session(t, "web", "web_user")
+    with mock.patch("sys.argv", ["solvent", "--json"]):
+        buf = StringIO()
+        with mock.patch("sys.stdout", buf):
+            with mock.patch("solvent.treasury.Treasury", return_value=t):
+                from solvent.sessions_cmd import main
+                main()
+    data = json.loads(buf.getvalue())
+    assert data[0]["channel"] == "web"


### PR DESCRIPTION
## Summary

- Adds `solvent sessions` CLI command (`solvent/sessions_cmd.py`) for operator visibility into active chat sessions
- List view shows all sessions across channels (or filtered with `--channel`) with user label, last-updated timestamp, and message count
- Detail view (`--show <session_id>`) prints the full chronological message history, truncating long content at 120 chars
- Supports `--json` for machine-readable output and `-n N` to cap list length
- Wires `solvent sessions` into `solvent/__main__.py`

## Test plan

- [ ] 15 new tests in `tests/test_sessions_cmd.py` covering list/filter/limit, message count, missing-label fallback, detail view, not-found, no-messages, content truncation, JSON mode, and CLI dispatch
- [ ] 265 total tests pass (6 skipped, 0 regressions)
- [ ] `solvent sessions` shows all sessions with message counts
- [ ] `solvent sessions --channel telegram` filters correctly
- [ ] `solvent sessions --show telegram:12345` shows dated role/content lines
- [ ] `solvent sessions --json` emits a JSON array

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SGjM79GJpSksy9wSSBa7e6

---
_Generated by [Claude Code](https://claude.ai/code/session_01SGjM79GJpSksy9wSSBa7e6)_