### PR TITLE
add: solvent metrics — per-job cost accuracy, margin and speed stats

### DIFF
--- a/solvent/__main__.py
+++ b/solvent/__main__.py
@@ -52,6 +52,10 @@ def main():
         s = SolventStages(treasury=t, guard=Guardrails(t), stripe=StripeClient())
         result = s.retry_job(job_id)
         import json; print(json.dumps(result, indent=2, default=str))
+    elif len(sys.argv) > 1 and sys.argv[1] == "metrics":
+        sys.argv.pop(1)
+        from .metrics_cmd import main as metrics_main
+        metrics_main()
     elif len(sys.argv) > 1 and sys.argv[1] == "webhooks":
         from .webhook_log import WebhookLog
         import json

--- a/solvent/metrics_cmd.py
+++ b/solvent/metrics_cmd.py
@@ -1,0 +1,203 @@
+"""
+metrics_cmd.py — per-job performance metrics for SOLVENT.
+
+Shows cost accuracy, margin drift, fulfillment speed, and tool usage
+from the treasury job_metrics table.
+
+Usage:
+    solvent metrics                         show last 20 job metrics
+    solvent metrics -n 50                   show last 50
+    solvent metrics --job <id>              show metrics for one job
+    solvent metrics --slow                  only jobs taking > 30s
+    solvent metrics --drifted               only jobs with cost overrun > 15%
+    solvent metrics --json                  output raw JSON
+    solvent metrics --summary               aggregate stats (avg margin, speed)
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from datetime import datetime, timezone
+from typing import Optional
+
+
+def _fmt_ts(ts: float) -> str:
+    dt = datetime.fromtimestamp(ts, tz=timezone.utc).astimezone()
+    return dt.strftime("%Y-%m-%d %H:%M")
+
+
+def _pct(value) -> str:
+    if value is None:
+        return "  n/a"
+    return f"{value:>5.1f}%"
+
+
+def _cents(value) -> str:
+    if value is None:
+        return "  n/a  "
+    return f"${value / 100:>6.2f}"
+
+
+def _secs(value) -> str:
+    if value is None:
+        return "   n/a"
+    return f"{value:>5.1f}s"
+
+
+def _human_line(m: dict) -> str:
+    job = (m.get("job_id") or "")[:12]
+    ts = _fmt_ts(m["ts"])
+    est_margin = _pct(m.get("est_margin_pct"))
+    act_margin = _pct(m.get("actual_margin_pct"))
+    drift = m.get("margin_drift_cents")
+    drift_str = f"drift {_cents(drift)}" if drift is not None else ""
+    speed = _secs(m.get("fulfillment_seconds"))
+    tools = m.get("tool_calls")
+    tools_str = f"{tools}t" if tools is not None else ""
+    flags = []
+    if m.get("decline_reason"):
+        flags.append("DECLINED")
+    if m.get("block_rule"):
+        flags.append("BLOCKED")
+    if m.get("refunded"):
+        flags.append("REFUNDED")
+    flag_str = "  [" + ",".join(flags) + "]" if flags else ""
+    return (
+        f"{ts}  [{job:<12}]  "
+        f"est {est_margin}  act {act_margin}  {drift_str:<18}  "
+        f"{speed}  {tools_str:<4}{flag_str}"
+    )
+
+
+def _summary(metrics: list[dict]) -> dict:
+    completed = [m for m in metrics if m.get("actual_margin_pct") is not None]
+    n = len(completed)
+    declined = sum(1 for m in metrics if m.get("decline_reason"))
+    blocked = sum(1 for m in metrics if m.get("block_rule"))
+    refunded = sum(1 for m in metrics if m.get("refunded"))
+
+    base = {
+        "total": len(metrics),
+        "completed": n,
+        "declined": declined,
+        "blocked": blocked,
+        "refunded": refunded,
+    }
+    if not n:
+        return base
+
+    avg_margin = sum(m["actual_margin_pct"] for m in completed) / n
+    speeds = [m["fulfillment_seconds"] for m in completed if m.get("fulfillment_seconds") is not None]
+    avg_speed = sum(speeds) / len(speeds) if speeds else None
+    drifted = [m for m in completed
+               if m.get("margin_drift_cents") is not None
+               and m.get("est_cost_cents")
+               and abs(m["margin_drift_cents"]) > m["est_cost_cents"] * 0.15]
+
+    base.update(
+        avg_actual_margin_pct=round(avg_margin, 1),
+        avg_fulfillment_seconds=round(avg_speed, 1) if avg_speed is not None else None,
+        cost_overruns=len(drifted),
+    )
+    return base
+
+
+def show_metrics(
+    treasury=None,
+    *,
+    n: int = 20,
+    job: Optional[str] = None,
+    slow_threshold: Optional[float] = None,
+    drifted_only: bool = False,
+    as_json: bool = False,
+    summary: bool = False,
+) -> None:
+    if treasury is None:
+        from .treasury import Treasury
+        treasury = Treasury()
+
+    if job:
+        m = treasury.get_metrics(job)
+        rows = [m] if m else []
+    else:
+        rows = list(treasury.list_metrics())
+        rows.reverse()  # newest first
+
+    # Filters
+    if slow_threshold is not None:
+        rows = [r for r in rows if (r.get("fulfillment_seconds") or 0) >= slow_threshold]
+    if drifted_only:
+        rows = [
+            r for r in rows
+            if r.get("margin_drift_cents") is not None
+            and r.get("est_cost_cents")
+            and abs(r["margin_drift_cents"]) > r["est_cost_cents"] * 0.15
+        ]
+
+    rows = rows[:n]
+
+    if summary:
+        s = _summary(rows if rows else list(treasury.list_metrics()))
+        if as_json:
+            print(json.dumps(s, indent=2))
+        else:
+            print("Job metrics summary")
+            print(f"  Total jobs        {s['total']}")
+            print(f"  Completed         {s['completed']}")
+            if s.get("avg_actual_margin_pct") is not None:
+                print(f"  Avg actual margin {s['avg_actual_margin_pct']}%")
+            if s.get("avg_fulfillment_seconds") is not None:
+                print(f"  Avg fulfillment   {s['avg_fulfillment_seconds']}s")
+            print(f"  Cost overruns     {s.get('cost_overruns', 0)}")
+            print(f"  Declined          {s.get('declined', 0)}")
+            print(f"  Blocked           {s.get('blocked', 0)}")
+            print(f"  Refunded          {s.get('refunded', 0)}")
+        return
+
+    if not rows:
+        print("(no job metrics)")
+        return
+
+    if as_json:
+        print(json.dumps(rows, indent=2, default=str))
+        return
+
+    print(f"  {len(rows)} metric(s) shown (newest first)\n")
+    for m in rows:
+        print(_human_line(m))
+
+
+def main() -> None:
+    import argparse
+
+    p = argparse.ArgumentParser(
+        description="Show per-job performance metrics (cost accuracy, speed, margin).",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    p.add_argument("-n", "--lines", type=int, default=20, metavar="N",
+                   help="number of rows to show (default 20)")
+    p.add_argument("--job", metavar="JOB_ID",
+                   help="show metrics for a specific job")
+    p.add_argument("--slow", dest="slow", type=float, nargs="?", const=30.0, metavar="SECS",
+                   help="only jobs taking >= SECS seconds (default 30)")
+    p.add_argument("--drifted", dest="drifted", action="store_true",
+                   help="only jobs where actual cost exceeded estimate by > 15%%")
+    p.add_argument("--summary", action="store_true",
+                   help="show aggregate stats instead of per-row lines")
+    p.add_argument("--json", dest="as_json", action="store_true",
+                   help="output raw JSON")
+    args = p.parse_args()
+
+    show_metrics(
+        n=args.lines,
+        job=args.job,
+        slow_threshold=args.slow,
+        drifted_only=args.drifted,
+        as_json=args.as_json,
+        summary=args.summary,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_metrics_cmd.py
+++ b/tests/test_metrics_cmd.py
@@ -1,0 +1,220 @@
+"""Tests for solvent/metrics_cmd.py."""
+
+from __future__ import annotations
+
+import json
+from io import StringIO
+from pathlib import Path
+from unittest import mock
+
+import pytest
+
+from solvent.metrics_cmd import _summary, show_metrics
+from solvent.treasury import Treasury
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_treasury(tmp_path: Path) -> Treasury:
+    return Treasury(path=tmp_path / "solvent.db")
+
+
+def _upsert(t: Treasury, job_id: str, **kwargs) -> None:
+    t.upsert_metrics(job_id, **kwargs)
+
+
+def _capture(treasury, **kwargs) -> str:
+    buf = StringIO()
+    with mock.patch("sys.stdout", buf):
+        show_metrics(treasury, **kwargs)
+    return buf.getvalue()
+
+
+# ---------------------------------------------------------------------------
+# _summary
+# ---------------------------------------------------------------------------
+
+def test_summary_empty():
+    s = _summary([])
+    assert s["total"] == 0
+    assert s["completed"] == 0
+
+
+def test_summary_with_data():
+    rows = [
+        {"actual_margin_pct": 40.0, "fulfillment_seconds": 10.0,
+         "margin_drift_cents": 0, "est_cost_cents": 100,
+         "decline_reason": None, "block_rule": None, "refunded": 0, "ts": 1.0},
+        {"actual_margin_pct": 60.0, "fulfillment_seconds": 20.0,
+         "margin_drift_cents": 5, "est_cost_cents": 100,
+         "decline_reason": None, "block_rule": None, "refunded": 0, "ts": 2.0},
+    ]
+    s = _summary(rows)
+    assert s["completed"] == 2
+    assert s["avg_actual_margin_pct"] == 50.0
+    assert s["avg_fulfillment_seconds"] == 15.0
+    assert s["cost_overruns"] == 0
+
+
+def test_summary_counts_overruns():
+    rows = [
+        {"actual_margin_pct": 30.0, "fulfillment_seconds": 5.0,
+         "margin_drift_cents": 20, "est_cost_cents": 100,  # 20% overrun
+         "decline_reason": None, "block_rule": None, "refunded": 0, "ts": 1.0},
+    ]
+    s = _summary(rows)
+    assert s["cost_overruns"] == 1
+
+
+def test_summary_counts_declined_blocked_refunded():
+    rows = [
+        {"actual_margin_pct": None, "decline_reason": "price_too_low",
+         "block_rule": None, "refunded": 0, "est_cost_cents": None,
+         "margin_drift_cents": None, "fulfillment_seconds": None, "ts": 1.0},
+        {"actual_margin_pct": None, "decline_reason": None,
+         "block_rule": "ip_ban", "refunded": 1, "est_cost_cents": None,
+         "margin_drift_cents": None, "fulfillment_seconds": None, "ts": 2.0},
+    ]
+    s = _summary(rows)
+    assert s["declined"] == 1
+    assert s["blocked"] == 1
+    assert s["refunded"] == 1
+
+
+# ---------------------------------------------------------------------------
+# show_metrics
+# ---------------------------------------------------------------------------
+
+def test_empty_shows_no_metrics(tmp_path):
+    t = _make_treasury(tmp_path)
+    out = _capture(t)
+    assert "no job metrics" in out.lower()
+
+
+def test_shows_job_row(tmp_path):
+    t = _make_treasury(tmp_path)
+    _upsert(t, "job-abc123", est_margin_pct=45.0, actual_margin_pct=42.0,
+            fulfillment_seconds=12.5, tool_calls=3)
+    out = _capture(t, n=10)
+    assert "job-abc12" in out
+    assert "42.0%" in out
+    assert "12.5s" in out
+
+
+def test_newest_first(tmp_path):
+    t = _make_treasury(tmp_path)
+    _upsert(t, "job-first1", actual_margin_pct=10.0)
+    _upsert(t, "job-second", actual_margin_pct=20.0)
+    out = _capture(t, n=10)
+    assert out.index("job-second") < out.index("job-first")
+
+
+def test_filter_by_job(tmp_path):
+    t = _make_treasury(tmp_path)
+    _upsert(t, "job-aaa", actual_margin_pct=30.0)
+    _upsert(t, "job-bbb", actual_margin_pct=50.0)
+    out = _capture(t, job="job-aaa")
+    assert "job-aaa" in out
+    assert "job-bbb" not in out
+
+
+def test_job_not_found(tmp_path):
+    t = _make_treasury(tmp_path)
+    out = _capture(t, job="nonexistent")
+    assert "no job metrics" in out.lower()
+
+
+def test_filter_slow(tmp_path):
+    t = _make_treasury(tmp_path)
+    _upsert(t, "job-fast", fulfillment_seconds=5.0, actual_margin_pct=30.0)
+    _upsert(t, "job-slow", fulfillment_seconds=60.0, actual_margin_pct=30.0)
+    out = _capture(t, n=10, slow_threshold=30.0)
+    assert "job-slow" in out
+    assert "job-fast" not in out
+
+
+def test_filter_drifted(tmp_path):
+    t = _make_treasury(tmp_path)
+    _upsert(t, "job-ok11", est_cost_cents=100, margin_drift_cents=5,
+            actual_margin_pct=40.0)   # 5% drift — OK
+    _upsert(t, "job-bad1", est_cost_cents=100, margin_drift_cents=20,
+            actual_margin_pct=30.0)   # 20% drift — drifted
+    out = _capture(t, n=10, drifted_only=True)
+    assert "job-bad1" in out
+    assert "job-ok11" not in out
+
+
+def test_limit_n(tmp_path):
+    t = _make_treasury(tmp_path)
+    for i in range(10):
+        _upsert(t, f"jobtest{i:04d}", actual_margin_pct=float(i * 5))
+    out = _capture(t, n=3)
+    count = sum(1 for line in out.splitlines() if "jobtest" in line)
+    assert count == 3
+
+
+def test_flags_shown(tmp_path):
+    t = _make_treasury(tmp_path)
+    _upsert(t, "job-dec1", decline_reason="margin_too_low")
+    _upsert(t, "job-blk1", block_rule="ip_ban")
+    _upsert(t, "job-ref1", refunded=1, actual_margin_pct=30.0)
+    out = _capture(t, n=10)
+    assert "DECLINED" in out
+    assert "BLOCKED" in out
+    assert "REFUNDED" in out
+
+
+def test_json_mode(tmp_path):
+    t = _make_treasury(tmp_path)
+    _upsert(t, "job-json", actual_margin_pct=55.0, tool_calls=2)
+    out = _capture(t, n=5, as_json=True)
+    data = json.loads(out)
+    assert isinstance(data, list)
+    assert data[0]["job_id"] == "job-json"
+
+
+def test_summary_mode(tmp_path):
+    t = _make_treasury(tmp_path)
+    _upsert(t, "job-s1", actual_margin_pct=40.0, fulfillment_seconds=10.0)
+    _upsert(t, "job-s2", actual_margin_pct=60.0, fulfillment_seconds=20.0)
+    out = _capture(t, summary=True)
+    assert "Avg actual margin" in out
+    assert "50.0%" in out
+
+
+def test_summary_json(tmp_path):
+    t = _make_treasury(tmp_path)
+    _upsert(t, "job-sj", actual_margin_pct=45.0)
+    out = _capture(t, summary=True, as_json=True)
+    data = json.loads(out)
+    assert "avg_actual_margin_pct" in data
+
+
+# ---------------------------------------------------------------------------
+# CLI main dispatch
+# ---------------------------------------------------------------------------
+
+def test_main_runs(tmp_path):
+    t = _make_treasury(tmp_path)
+    _upsert(t, "job-cli1", actual_margin_pct=35.0)
+    with mock.patch("sys.argv", ["solvent"]):
+        buf = StringIO()
+        with mock.patch("sys.stdout", buf):
+            with mock.patch("solvent.treasury.Treasury", return_value=t):
+                from solvent.metrics_cmd import main
+                main()
+    assert "job-cli1" in buf.getvalue()
+
+
+def test_main_summary_flag(tmp_path):
+    t = _make_treasury(tmp_path)
+    _upsert(t, "job-cli2", actual_margin_pct=50.0)
+    with mock.patch("sys.argv", ["solvent", "--summary"]):
+        buf = StringIO()
+        with mock.patch("sys.stdout", buf):
+            with mock.patch("solvent.treasury.Treasury", return_value=t):
+                from solvent.metrics_cmd import main
+                main()
+    assert "summary" in buf.getvalue().lower()


### PR DESCRIPTION
## Summary

- Adds `solvent metrics` CLI command (`solvent/metrics_cmd.py`) that reads the treasury `job_metrics` table to show per-job cost accuracy, margin drift, fulfillment speed, and tool usage
- Line format: timestamp, job ID prefix, estimated vs actual margin %, drift in dollars, fulfillment seconds, tool call count, and flags (DECLINED / BLOCKED / REFUNDED)
- Filters: `--slow [SECS]` (≥30s default), `--drifted` (actual cost >15% above estimate), `--job <id>` for a single job
- `--summary` prints aggregate averages (margin, speed, overrun count) instead of per-row lines; `--json` outputs raw JSON in both modes

## Test plan

- [ ] 18 new tests in `tests/test_metrics_cmd.py` covering `_summary` logic, per-row display, all filters, flags, limit-n, JSON mode, summary mode, and CLI dispatch
- [ ] 268 total tests pass (6 skipped, 0 regressions)
- [ ] `solvent metrics` shows newest jobs first with margin/speed columns
- [ ] `solvent metrics --slow 60` shows only jobs taking ≥ 60s
- [ ] `solvent metrics --drifted` shows only cost-overrun jobs
- [ ] `solvent metrics --summary --json` returns a JSON object with aggregate fields

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SGjM79GJpSksy9wSSBa7e6

---
_Generated by [Claude Code](https://claude.ai/code/session_01SGjM79GJpSksy9wSSBa7e6)_