### PR TITLE
fix: protect brief API routes

### DIFF
--- a/solvent/server.py
+++ b/solvent/server.py
@@ -232,6 +232,12 @@ def create_app(seed_cents: int = 10_000, fresh: bool = False) -> object:
         metrics = agent.t.get_metrics(job_id)
         return {"job": dict(row), "metrics": metrics}
 
+    def _is_local_request(request: Request | None) -> bool:
+        if request is None:
+            return False
+        client_host = getattr(request.client, "host", "") if request.client else ""
+        return client_host in ("127.0.0.1", "::1", "localhost", "testclient")
+
     @app.get("/api/receipt/{job_id}")
     def get_receipt(job_id: str, token: str = "", request: Request = None):
         """Return a plaintext job receipt.
@@ -246,12 +252,7 @@ def create_app(seed_cents: int = 10_000, fresh: bool = False) -> object:
             raise HTTPException(404, "job not found")
 
         # Auth: localhost OR valid delivery token
-        is_local = False
-        if request is not None:
-            client_host = getattr(request.client, "host", "") if request.client else ""
-            is_local = client_host in ("127.0.0.1", "::1", "localhost", "testclient")
-
-        if not is_local:
+        if not _is_local_request(request):
             if not verify_delivery_token(job_id, token):
                 raise HTTPException(403, "invalid or expired delivery token")
 
@@ -309,7 +310,9 @@ def create_app(seed_cents: int = 10_000, fresh: bool = False) -> object:
         raise HTTPException(404, "brief not found")
 
     @app.get("/api/briefs")
-    def list_briefs():
+    def list_briefs(request: Request = None):
+        if not _is_local_request(request):
+            raise HTTPException(403, "brief listing is only available locally")
         reports_dir = reports_dir_fn()
         if not reports_dir.is_dir():
             return []
@@ -320,7 +323,9 @@ def create_app(seed_cents: int = 10_000, fresh: bool = False) -> object:
         return sorted(list(stems))
 
     @app.get("/api/briefs/{job_id}")
-    def get_brief_api(job_id: str):
+    def get_brief_api(job_id: str, token: str = "", request: Request = None):
+        if not _is_local_request(request) and not verify_delivery_token(job_id, token):
+            raise HTTPException(403, "invalid or expired delivery token")
         reports_dir = reports_dir_fn().resolve()
 
         path_html = (reports_dir / f"{job_id}.html").resolve()

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -38,6 +38,31 @@ class TestHostedBriefs(unittest.TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertIn("Private brief", response.text)
 
+    def test_api_brief_routes_require_localhost_or_delivery_token(self):
+        try:
+            from fastapi.testclient import TestClient
+        except ImportError:
+            self.skipTest("FastAPI test client is not installed")
+
+        client = TestClient(create_app())
+
+        listed = client.get("/api/briefs")
+        self.assertEqual(listed.status_code, 200)
+        self.assertIn("victim-job", listed.json())
+
+        response = client.get("/api/briefs/victim-job")
+        self.assertEqual(response.status_code, 200)
+        self.assertIn("Private brief", response.text)
+
+        remote_client = TestClient(create_app(), client=("203.0.113.10", 12345))
+        self.assertEqual(remote_client.get("/api/briefs").status_code, 403)
+        self.assertEqual(remote_client.get("/api/briefs/victim-job").status_code, 403)
+
+        token = make_delivery_token("victim-job")
+        response = remote_client.get(f"/api/briefs/victim-job?token={token}")
+        self.assertEqual(response.status_code, 200)
+        self.assertIn("Private brief", response.text)
+
     def test_interactive_dashboard_routes(self):
         try:
             from fastapi.testclient import TestClient


### PR DESCRIPTION
### Motivation
- The `/api/briefs` and `/api/briefs/{job_id}` endpoints exposed delivered research briefs without calling `verify_delivery_token`, allowing remote enumeration and disclosure of customer briefs.
- The change restores the intended access model where hosted briefs require either a valid delivery token or local-only access for dashboard previewing.

### Description
- Add a shared helper `_is_local_request(request)` to detect localhost/testclient callers and reuse it for authorization checks.
- Keep the canonical hosted route `GET /briefs/{job_id}` protected by `verify_delivery_token`, and require either localhost or a valid token for `GET /api/briefs/{job_id}` by adding `token` and `request` parameters and enforcing `verify_delivery_token` for non-local requests.
- Restrict `GET /api/briefs` enumeration to local requests only by adding a `request` parameter and returning `403` for remote callers.
- Refactor `GET /api/receipt/{job_id}` to use the new `_is_local_request` helper for consistent localhost-or-token authorization, and add a regression test `test_api_brief_routes_require_localhost_or_delivery_token` in `tests/test_server.py` covering local listing/read, remote rejection, and remote token access.

### Testing
- Ran `python -m pytest tests/test_server.py`, which executed but skipped tests because the FastAPI test client is not available in the environment (tests are guarded and skipped when `fastapi.testclient` is absent).
- Compiled the modified files with `python -m compileall solvent/server.py tests/test_server.py`, which succeeded without syntax errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a500668c708832e82e161af28b3ceae)