### PR TITLE
Prevent dashboard chat from loading private MEMORY.md

### DIFF
--- a/solvent/workspace.py
+++ b/solvent/workspace.py
@@ -309,8 +309,8 @@ def build_system_prompt(
 
 
 def build_chat_system_prompt(channel: str = "cli") -> str:
-    """Gateway/chat entry — private channels get MEMORY.md."""
-    session_kind = "main" if channel in ("cli", "telegram", "interactive", "dashboard") else "shared"
+    """Gateway/chat entry — authenticated private channels get MEMORY.md."""
+    session_kind = "main" if channel in ("cli", "telegram", "interactive") else "shared"
     return build_system_prompt(session_kind=session_kind)
 
 

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -44,6 +44,16 @@ class TestWorkspace(unittest.TestCase):
         self.assertIn("SECRET_USER_FACT", main_prompt)
         self.assertNotIn("SECRET_USER_FACT", shared_prompt)
 
+    def test_dashboard_chat_uses_shared_prompt_without_memory(self):
+        workspace.seed_workspace()
+        (workspace.workspace_path() / "MEMORY.md").write_text(
+            "DASHBOARD_PRIVATE_MEMORY_SECRET\n", encoding="utf-8"
+        )
+        cli_prompt = workspace.build_chat_system_prompt("cli")
+        dashboard_prompt = workspace.build_chat_system_prompt("dashboard")
+        self.assertIn("DASHBOARD_PRIVATE_MEMORY_SECRET", cli_prompt)
+        self.assertNotIn("DASHBOARD_PRIVATE_MEMORY_SECRET", dashboard_prompt)
+
     def test_append_daily_memory(self):
         workspace.seed_workspace()
         path = workspace.append_daily_memory("test event")


### PR DESCRIPTION
### Motivation
- The `dashboard` channel was classified as a private/main session and therefore received `MEMORY.md` in the LLM system prompt, which exposed operator long-term memory to unauthenticated `/api/chat` requests.

### Description
- Remove `"dashboard"` from the private/main channel tuple in `build_chat_system_prompt` so dashboard chat uses the shared prompt path and does not include `MEMORY.md`.
- Update the function docstring to clarify that only authenticated private channels receive memory.
- Add a regression test `test_dashboard_chat_uses_shared_prompt_without_memory` in `tests/test_workspace.py` that verifies CLI still gets memory but `dashboard` does not.

### Testing
- Ran `python -m pytest tests/test_workspace.py tests/test_dashboard_chat.py tests/test_server.py` and all relevant tests passed (7 passed, 3 skipped).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a5007f48604832eb4821eff0c1fb96d)