### PR TITLE
Fix chat job ID hijacking

### DIFF
--- a/solvent/chat.py
+++ b/solvent/chat.py
@@ -21,6 +21,15 @@ _EMAIL_RE = re.compile(r"[\w.+-]+@[\w.-]+\.\w+")
 _BUDGET_RE = re.compile(r"(?:budget|pay|spend)\s*[:\$]?\s*\$?(\d+(?:\.\d{1,2})?)", re.I)
 
 
+def _new_chat_job_id(agent: Solvent) -> str:
+    """Generate a server-owned chat job ID that does not overwrite an existing job."""
+    for _ in range(10):
+        job_id = "T" + uuid.uuid4().hex[:8]
+        if not agent.t.get_job(job_id):
+            return job_id
+    return "T" + uuid.uuid4().hex
+
+
 def _make_executor(agent: Solvent, session_id: str, live_search: bool):
     ctx = tools.ToolContext()
 
@@ -65,7 +74,7 @@ def _make_executor(agent: Solvent, session_id: str, live_search: bool):
             topic = args.get("topic", "")
             budget = int(args.get("budget_cents", 0))
             email = args.get("customer_email", "client@example.com")
-            job_id = args.get("job_id") or ("T" + uuid.uuid4().hex[:8])
+            job_id = _new_chat_job_id(agent)
             job = {
                 "id": job_id,
                 "topic": topic,
@@ -77,7 +86,8 @@ def _make_executor(agent: Solvent, session_id: str, live_search: bool):
                 "context": f"Commissioned via chat session {session_id}",
             }
             result = agent.enqueue_job(job)
-            agent.t.update_chat_session(session_id, notify_job_id=job_id, pending_job_json="")
+            if result.get("stage") != "declined" and not result.get("error"):
+                agent.t.update_chat_session(session_id, notify_job_id=job_id, pending_job_json="")
             if result.get("url"):
                 return json.dumps({
                     "job_id": job_id,

--- a/tests/test_chat_tools.py
+++ b/tests/test_chat_tools.py
@@ -1,3 +1,4 @@
+import os
 import tempfile
 import unittest
 from pathlib import Path
@@ -12,6 +13,8 @@ from solvent.treasury import Treasury
 
 class TestChatTools(unittest.TestCase):
     def setUp(self):
+        self._env = patch.dict(os.environ, {"SOLVENT_DELIVERY_SECRET": "x" * 32}, clear=False)
+        self._env.start()
         self.tmp = tempfile.TemporaryDirectory()
         self.db = Path(self.tmp.name) / "t.db"
         self.t = Treasury(path=self.db)
@@ -24,6 +27,7 @@ class TestChatTools(unittest.TestCase):
 
     def tearDown(self):
         self.tmp.cleanup()
+        self._env.stop()
 
     def test_format_job_notification(self):
         msg = format_job_notification({"stage": "delivered", "job_id": "J1", "url": "https://x"})
@@ -73,6 +77,42 @@ class TestChatTools(unittest.TestCase):
 
         self.assertLessEqual(calls["n"], 5)
         self.assertIn("set", reply.lower())
+
+    @patch.object(nemotron, "complete")
+    def test_submit_brief_ignores_tool_supplied_job_id(self, mock_complete):
+        self.t.upsert_job(
+            "VICTIM1",
+            "awaiting_payment",
+            topic="Victim topic",
+            budget_cents=7500,
+            customer_email="victim@example.com",
+            job_payload_json={"id": "VICTIM1", "topic": "Victim topic"},
+        )
+        mock_complete.side_effect = [
+            (
+                '<tool_call>{"name": "submit_brief", "arguments": '
+                '{"job_id": "VICTIM1", "topic": "Attacker topic", '
+                '"budget_cents": 5000, "customer_email": "attacker@example.com"}}</tool_call>',
+                {},
+            ),
+            ("Done.", {}),
+        ]
+
+        handle_message(
+            self.session["id"],
+            "Submit a brief",
+            agent=self.agent,
+            memory=self.memory,
+        )
+
+        victim = self.t.get_job("VICTIM1")
+        self.assertEqual(victim["topic"], "Victim topic")
+        self.assertEqual(victim["customer_email"], "victim@example.com")
+        session = self.t.get_chat_session(self.session["id"])
+        self.assertNotEqual(session.get("notify_job_id"), "VICTIM1")
+        created = [j for j in self.t.list_jobs() if j["id"] != "VICTIM1"]
+        self.assertEqual(len(created), 1)
+        self.assertEqual(created[0]["topic"], "Attacker topic")
 
     @patch.object(nemotron, "complete")
     def test_submit_brief_via_tool(self, mock_complete):


### PR DESCRIPTION
### Motivation

- The chat `submit_brief` tool previously honored model/user-supplied `job_id`, allowing an attacker to overwrite existing jobs and subscribe to another session's job notifications (IDOR). 
- Job notification binding used `notify_job_id` without validating ownership or that a new job was actually accepted, enabling information leakage and unauthorized delivery link exposure.

### Description

- Stop honoring `job_id` from tool arguments by generating server-owned IDs with a uniqueness check via a new helper `
_new_chat_job_id(agent)` in `solvent/chat.py`.
- Replace the previous `args.get("job_id")` logic so `submit_brief` always uses the server-generated job ID and creates a fresh job payload before enqueueing.
- Only set the chat session `notify_job_id` when the submission was accepted (i.e. not `declined` and no `error`) to avoid subscribing sessions to failed or malicious updates.
- Add a regression test `test_submit_brief_ignores_tool_supplied_job_id` in `tests/test_chat_tools.py` that seeds a victim job, submits a malicious tool call with that job ID, and asserts the victim job is unchanged while a new job is created and the session is not subscribed to the victim ID.

### Testing

- Ran `python -m pytest tests/test_chat_tools.py`, which passed the new and existing chat tool tests (`6 passed`).
- Ran the full suite with `python -m pytest`, which completed successfully (`418 passed, 7 skipped`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a5009d4b428832eabe849392322957b)