### PR TITLE
Require delivery token for brief API access and disable public brief listing

### DIFF
--- a/solvent/dashboard.py
+++ b/solvent/dashboard.py
@@ -1210,13 +1210,17 @@ def render(snapshot: dict, log: list[dict], *, live: bool = False) -> Path:
     function openBriefModal(jobId) {{
       document.getElementById("modal-title").innerText = "Research Brief Preview: " + jobId;
       const iframe = document.getElementById("brief-iframe");
-      iframe.src = `http://localhost:8787/api/briefs/${{jobId}}`;
+      const reportText = briefs[jobId] || "_No report brief generated or found in data/reports._";
+      iframe.removeAttribute("src");
+      iframe.srcdoc = renderMarkdown(reportText);
       document.getElementById("brief-modal").classList.add("open");
     }}
 
     function closeBriefModal() {{
       document.getElementById("brief-modal").classList.remove("open");
-      document.getElementById("brief-iframe").src = "about:blank";
+      const iframe = document.getElementById("brief-iframe");
+      iframe.removeAttribute("srcdoc");
+      iframe.src = "about:blank";
     }}
 
     function updateBriefsList() {{

--- a/solvent/server.py
+++ b/solvent/server.py
@@ -232,35 +232,19 @@ def create_app(seed_cents: int = 10_000, fresh: bool = False) -> object:
                 return HTMLResponse(markdown_to_html(path_md.read_text(encoding="utf-8")))
         except ValueError:
             raise HTTPException(404, "brief not found") from None
-            
-        if reports_dir.is_dir():
-            for p in reports_dir.glob("*"):
-                if job_id in p.stem and p.suffix in (".html", ".md"):
-                    try:
-                        resolved_p = p.resolve()
-                        resolved_p.relative_to(reports_dir)
-                        if resolved_p.suffix == ".html":
-                            return HTMLResponse(resolved_p.read_text(encoding="utf-8"))
-                        else:
-                            return HTMLResponse(markdown_to_html(resolved_p.read_text(encoding="utf-8")))
-                    except ValueError:
-                        pass
-                        
+
         raise HTTPException(404, "brief not found")
 
     @app.get("/api/briefs")
     def list_briefs():
-        reports_dir = Path(__file__).resolve().parent.parent / "data" / "reports"
-        if not reports_dir.is_dir():
-            return []
-        stems = set()
-        for p in reports_dir.glob("*"):
-            if p.suffix in (".md", ".html") and p.stem != ".gitkeep":
-                stems.add(p.stem)
-        return sorted(list(stems))
+        raise HTTPException(403, "brief listing is not available")
 
     @app.get("/api/briefs/{job_id}")
-    def get_brief_api(job_id: str):
+    def get_brief_api(job_id: str, token: str = ""):
+        if not is_safe_job_id(job_id):
+            raise HTTPException(404, "brief not found")
+        if not verify_delivery_token(job_id, token):
+            raise HTTPException(403, "invalid or expired delivery token")
         reports_dir = (Path(__file__).resolve().parent.parent / "data" / "reports").resolve()
         
         path_html = (reports_dir / f"{job_id}.html").resolve()
@@ -278,20 +262,7 @@ def create_app(seed_cents: int = 10_000, fresh: bool = False) -> object:
                 return HTMLResponse(markdown_to_html(path_md.read_text(encoding="utf-8")))
         except ValueError:
             raise HTTPException(404, "brief not found") from None
-            
-        if reports_dir.is_dir():
-            for p in reports_dir.glob("*"):
-                if job_id in p.stem and p.suffix in (".html", ".md"):
-                    try:
-                        resolved_p = p.resolve()
-                        resolved_p.relative_to(reports_dir)
-                        if resolved_p.suffix == ".html":
-                            return HTMLResponse(resolved_p.read_text(encoding="utf-8"))
-                        else:
-                            return HTMLResponse(markdown_to_html(resolved_p.read_text(encoding="utf-8")))
-                    except ValueError:
-                        pass
-                        
+
         raise HTTPException(404, "brief not found")
 
     return app

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -38,6 +38,32 @@ class TestHostedBriefs(unittest.TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertIn("Private brief", response.text)
 
+    def test_brief_api_requires_delivery_token(self):
+        try:
+            from fastapi.testclient import TestClient
+        except ImportError:
+            self.skipTest("FastAPI test client is not installed")
+
+        client = TestClient(create_app())
+        response = client.get("/api/briefs/victim-job")
+        self.assertEqual(response.status_code, 403)
+
+        token = make_delivery_token("victim-job")
+        response = client.get(f"/api/briefs/victim-job?token={token}")
+        self.assertEqual(response.status_code, 200)
+        self.assertIn("Private brief", response.text)
+
+    def test_brief_api_does_not_enumerate_report_ids(self):
+        try:
+            from fastapi.testclient import TestClient
+        except ImportError:
+            self.skipTest("FastAPI test client is not installed")
+
+        client = TestClient(create_app())
+        response = client.get("/api/briefs")
+        self.assertEqual(response.status_code, 403)
+        self.assertNotIn("victim-job", response.text)
+
     def test_interactive_dashboard_routes(self):
         try:
             from fastapi.testclient import TestClient


### PR DESCRIPTION
### Motivation
- Close an authorization bypass where the new `/api/briefs` and `/api/briefs/{job_id}` routes allowed enumeration and retrieval of delivered research briefs without the HMAC delivery token.
- Prevent the dashboard preview from hardcoding a tokenless API URL that would institutionalize the insecure path.

### Description
- Change `list_briefs()` in `solvent/server.py` to return `HTTPException(403, "brief listing is not available")` to disable unauthenticated enumeration of report IDs.
- Change `/api/briefs/{job_id}` handler in `solvent/server.py` to accept a `token` parameter and enforce `is_safe_job_id(job_id)` and `verify_delivery_token(job_id, token)` before returning content, and remove the substring-fallback report lookup to preserve exact-id semantics.
- Update the dashboard preview in `solvent/dashboard.py` so `openBriefModal` uses the preloaded `briefs` map and sets `iframe.srcdoc = renderMarkdown(reportText)` (removing the hardcoded `http://localhost:8787/api/briefs/${jobId}` call) so previews do not depend on the unauthenticated API.
- Add regression tests in `tests/test_server.py` (`test_brief_api_requires_delivery_token` and `test_brief_api_does_not_enumerate_report_ids`) to assert token enforcement and disabled enumeration.

### Testing
- Ran targeted tests with `python -m pytest tests/test_server.py -q` which passed (FastAPI-dependent cases are skipped when dependencies are absent).
- Ran the full test suite with `python -m pytest -q` which completed successfully: `143 passed, 5 skipped`.
- Performed static checks by compiling with `python -m py_compile solvent/server.py solvent/dashboard.py tests/test_server.py` and ran `git diff --check` with no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a3962c05d948324ae4938e95220ab39)