### PR TITLE
Fix dashboard chat notification routing

### DIFF
--- a/solvent/dashboard_chat.py
+++ b/solvent/dashboard_chat.py
@@ -290,12 +290,12 @@ LIVE_CLIENT_JS = """
     }
 
     if (typeof EventSource !== 'undefined') {
-      const es = new EventSource('/api/events');
+      const es = new EventSource('/api/events?session_id=' + encodeURIComponent(chatSessionId));
       es.onmessage = (ev) => {
         try {
           const msg = JSON.parse(ev.data);
           if (msg.type === 'status' && msg.data) applyStatus(msg.data);
-          if (msg.type === 'chat' && msg.role === 'assistant') {
+          if (msg.type === 'chat' && msg.role === 'assistant' && msg.channel === 'dashboard' && (!msg.session_id || msg.session_id === chatSessionId)) {
             appendChat('assistant', msg.text);
             speak(msg.text);
           }

--- a/solvent/gateway.py
+++ b/solvent/gateway.py
@@ -25,11 +25,12 @@ def notify(channel: str, external_id: str, text: str) -> None:
     handler = _outbound_handlers.get(channel)
     if handler:
         handler(external_id, text)
-    try:
-        from .notifications import enqueue_chat
-        enqueue_chat(channel, external_id, text)
-    except Exception:
-        pass
+    if channel == "dashboard":
+        try:
+            from .notifications import enqueue_chat
+            enqueue_chat(channel, external_id, text)
+        except Exception:
+            pass
 
 
 def _rate_ok(user_key: str) -> bool:

--- a/solvent/server.py
+++ b/solvent/server.py
@@ -89,7 +89,15 @@ def create_app(seed_cents: int = 10_000, fresh: bool = False) -> object:
     agent.on_event = _on_agent_event
 
     def _dashboard_outbound(external_id: str, text: str) -> None:
-        hub.publish("chat", {"role": "assistant", "text": text, "session_id": external_id})
+        hub.publish(
+            "chat",
+            {
+                "role": "assistant",
+                "text": text,
+                "session_id": external_id,
+                "channel": "dashboard",
+            },
+        )
 
     register_outbound("dashboard", _dashboard_outbound)
 
@@ -114,13 +122,15 @@ def create_app(seed_cents: int = 10_000, fresh: bool = False) -> object:
                             hub.publish("status", {"data": data})
                     from .notifications import drain_chat_outbox
                     for row in drain_chat_outbox():
+                        if row.get("channel") != "dashboard":
+                            continue
                         hub.publish(
                             "chat",
                             {
                                 "role": "assistant",
                                 "text": row.get("text", ""),
                                 "session_id": row.get("external_id", ""),
-                                "channel": row.get("channel", ""),
+                                "channel": "dashboard",
                             },
                         )
                 except Exception:
@@ -144,7 +154,8 @@ def create_app(seed_cents: int = 10_000, fresh: bool = False) -> object:
         return JSONResponse(_refresh_status())
 
     @app.get("/api/events")
-    async def api_events():
+    async def api_events(request: Request):
+        session_id = request.query_params.get("session_id", "")
         q = hub.subscribe()
 
         async def stream():
@@ -153,6 +164,12 @@ def create_app(seed_cents: int = 10_000, fresh: bool = False) -> object:
                 while True:
                     try:
                         msg = await asyncio.wait_for(q.get(), timeout=15.0)
+                        if msg.get("type") == "chat":
+                            if msg.get("channel") != "dashboard":
+                                continue
+                            target_session = msg.get("session_id", "")
+                            if target_session and target_session != session_id:
+                                continue
                         yield EventHub.sse_format(msg)
                     except asyncio.TimeoutError:
                         yield EventHub.sse_format({"type": "ping", "ts": time.time()})

--- a/tests/test_gateway.py
+++ b/tests/test_gateway.py
@@ -47,3 +47,11 @@ class TestGateway(unittest.TestCase):
         register_outbound("testchan", handler)
         notify("testchan", "42", "hello")
         self.assertEqual(sent, [("42", "hello")])
+
+    def test_notify_only_enqueues_dashboard_notifications(self):
+        with patch("solvent.notifications.enqueue_chat") as enqueue_chat:
+            notify("telegram", "42", "private")
+            enqueue_chat.assert_not_called()
+
+            notify("dashboard", "web-1", "hello")
+            enqueue_chat.assert_called_once_with("dashboard", "web-1", "hello")


### PR DESCRIPTION
### Motivation
- Prevent cross-channel leakage where private/channel-specific notifications (e.g. Telegram) were enqueued to the shared outbox and broadcast to all dashboard SSE clients, which could disclose bearer delivery URLs and other sensitive data.

### Description
- Restrict `notify()` to only enqueue outbox rows for the `dashboard` channel while still invoking registered outbound handlers for all channels (`solvent/gateway.py`).
- Filter drained outbox rows to only publish `channel == "dashboard"` and include `"channel": "dashboard"` in published chat payloads (`solvent/server.py`).
- Make the SSE `/api/events` endpoint accept a `session_id` query param and drop non-dashboard or mismatched `session_id` chat messages before streaming to clients (`solvent/server.py`).
- Have the browser subscribe to `/api/events?session_id=<id>` and ignore SSE chat messages that are not `channel === 'dashboard'` or that target another session, and add a regression test ensuring `notify()` does not enqueue non-dashboard notifications (`solvent/dashboard_chat.py`, `tests/test_gateway.py`).

### Testing
- Ran targeted tests with `python -m pytest tests/test_gateway.py tests/test_notifications.py tests/test_server.py` and the subset passed (8 passed, 3 skipped).
- Ran full test suite with `python -m pytest` and observed all tests passing (144 passed, 3 skipped).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a395fb9531483248f64d21c8e831256)