### PR TITLE
fix(reconcile): actually detect double-booked revenue

### DIFF
--- a/solvent/reconcile.py
+++ b/solvent/reconcile.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import os
 import sys
+from collections import Counter
 from datetime import datetime, timedelta, timezone
 
 from .treasury import Treasury
@@ -19,21 +20,32 @@ except Exception:
 
 def reconcile(treasury: Treasury | None = None, since_days: int = 7) -> dict:
     treasury = treasury or Treasury()
-    ledger_refs = set()
-    session_refs = set()
+    # Count, don't just collect: the same PaymentIntent or Checkout Session
+    # booked as revenue twice is double-counted cash, which is exactly the
+    # drift reconciliation exists to catch.
+    ref_counts: Counter[str] = Counter()
+    session_counts: Counter[str] = Counter()
     for e in treasury.entries:
         if e.kind == "revenue":
             if e.stripe_ref:
-                ledger_refs.add(e.stripe_ref)
+                ref_counts[e.stripe_ref] += 1
             if e.stripe_session_id:
-                session_refs.add(e.stripe_session_id)
+                session_counts[e.stripe_session_id] += 1
+
+    ledger_refs = set(ref_counts)
+    duplicates = sorted(
+        {ident for ident, n in ref_counts.items() if n > 1}
+        | {ident for ident, n in session_counts.items() if n > 1}
+    )
 
     report = {
         "ledger_revenue_count": len(ledger_refs),
         "unmatched_stripe": [],
-        "unmatched_ledger": list(ledger_refs),
-        "duplicates": [],
-        "drift": False,
+        "unmatched_ledger": sorted(ledger_refs),
+        "duplicates": duplicates,
+        # Duplicates are detectable from the ledger alone, so they count as
+        # drift even when Stripe is unreachable.
+        "drift": bool(duplicates),
     }
 
     key = os.environ.get("STRIPE_API_KEY", "")
@@ -68,7 +80,7 @@ def reconcile(treasury: Treasury | None = None, since_days: int = 7) -> dict:
     unmatched_ledger = ledger_refs - stripe_pis
     report["unmatched_stripe"] = sorted(unmatched_stripe)
     report["unmatched_ledger"] = sorted(unmatched_ledger)
-    report["drift"] = bool(unmatched_stripe or unmatched_ledger)
+    report["drift"] = bool(unmatched_stripe or unmatched_ledger or duplicates)
     report["mode"] = "full"
     return report
 

--- a/tests/test_reconcile.py
+++ b/tests/test_reconcile.py
@@ -17,6 +17,49 @@ class TestReconcile(unittest.TestCase):
         self.assertIn("pi_sim_abc", report["unmatched_ledger"])
 
 
+class TestReconcileDuplicateDetection(unittest.TestCase):
+    """The `duplicates` field must actually report double-booked revenue."""
+
+    def _fresh(self):
+        t = Treasury()
+        t.reset()
+        t.seed(10_000)
+        return t
+
+    def test_duplicate_payment_intent_is_reported_as_drift(self):
+        t = self._fresh()
+        t.earn(5000, "job one", job_id="J1", stripe_ref="pi_dup")
+        t.earn(5000, "job one again", job_id="J2", stripe_ref="pi_dup")
+        report = reconcile(t)
+        self.assertIn("pi_dup", report["duplicates"])
+        self.assertTrue(report["drift"])
+
+    def test_distinct_refs_are_not_duplicates(self):
+        t = self._fresh()
+        t.earn(5000, "job one", job_id="J1", stripe_ref="pi_a")
+        t.earn(5000, "job two", job_id="J2", stripe_ref="pi_b")
+        report = reconcile(t)
+        self.assertEqual(report["duplicates"], [])
+        self.assertFalse(report["drift"])
+
+    def test_duplicates_are_sorted_and_deduplicated(self):
+        t = self._fresh()
+        for _ in range(3):
+            t.earn(1000, "thrice", job_id="J1", stripe_ref="pi_zzz")
+        t.earn(1000, "twice", job_id="J2", stripe_ref="pi_aaa")
+        t.earn(1000, "twice", job_id="J3", stripe_ref="pi_aaa")
+        report = reconcile(t)
+        self.assertEqual(report["duplicates"], ["pi_aaa", "pi_zzz"])
+
+    def test_clean_ledger_has_no_drift(self):
+        t = self._fresh()
+        t.earn(5000, "solo", job_id="J1", stripe_ref="pi_only")
+        report = reconcile(t)
+        self.assertEqual(report["mode"], "ledger_only")
+        self.assertEqual(report["duplicates"], [])
+        self.assertFalse(report["drift"])
+
+
 class TestReconcileLiveKeyRefusal(unittest.TestCase):
     def _report_with_key(self, key):
         import os as _os


### PR DESCRIPTION
## Summary

The reconcile report declared a `duplicates` field but never populated it. `duplicates` appeared exactly once in the entire codebase — in the dict literal — so every reconcile run reported `duplicates: []`.

Revenue refs were collected into a `set()`, so the same PaymentIntent or Checkout Session booked as revenue twice collapsed silently. This is the one failure mode a treasury reconciler exists to catch: a duplicated ref still matches Stripe exactly, so it is invisible to the `unmatched_stripe` / `unmatched_ledger` diffs while double-counting cash.

The `session_refs` scan was also dead — computed and never read.

## Changes
- Count refs and session ids (`Counter`) instead of set-collapsing them
- Populate `duplicates` with identifiers booked more than once
- Treat duplicates as `drift`, including in `ledger_only` mode, since they are detectable without reaching Stripe
- Sort `unmatched_ledger` for deterministic output

## Test Plan
- [x] 4 regression tests added; **2 fail against the previous implementation**, all pass after
- [x] Full suite: 489 passed, 2 skipped (was 485)
- [x] `ruff check` + `ruff format --check` clean

No behaviour change for clean ledgers: `duplicates` stays `[]` and `drift` stays `False`.