### PR TITLE
fix(tests): patch _HAS_STRIPE so reconcile tests pass without the stripe extra

### DIFF
--- a/tests/test_reconcile.py
+++ b/tests/test_reconcile.py
@@ -106,8 +106,18 @@ class TestReconcileStripeIntegration(unittest.TestCase):
             self._mock_stripe,
         )
         self._stripe_mod.start()
+        # Patching stripe_sdk alone is not enough: reconcile() gates the whole
+        # Stripe path on the module-level _HAS_STRIPE flag, which is False
+        # whenever the optional `stripe` extra is not installed (this is exactly
+        # the case in the "zero-dependency core" CI job). Without also forcing
+        # the flag True, reconcile() short-circuits to mode="ledger_only" and
+        # every assertion in this class fails -- but only in environments
+        # without stripe, so the suite passes locally and breaks in CI.
+        self._has_stripe = mock.patch("solvent.reconcile._HAS_STRIPE", True)
+        self._has_stripe.start()
 
     def tearDown(self):
+        self._has_stripe.stop()
         self._stripe_mod.stop()
 
     # ------------------------------------------------------------------


### PR DESCRIPTION
## Problem

The `zero-dependency core` CI job has been failing on `main`. It installs only `.[dev]`, so the optional `stripe` package is absent.

`TestReconcileStripeIntegration` patches `solvent.reconcile.stripe_sdk` but **not** the module-level `_HAS_STRIPE` flag. With `stripe` uninstalled that flag is `False`, so `reconcile()` hits this guard and returns early:

```python
if not key or not _HAS_STRIPE or key.startswith("sk_live_") ...:
    report["mode"] = "ledger_only"
    return report
```

Six tests then fail on assertions expecting `mode="full"`, populated `unmatched_*`, or a `stripe_error` key.

## Why it hid

`_HAS_STRIPE` is `True` whenever `stripe` happens to be installed, so the suite passes locally and in the `test (3.10/3.11/3.12)` and `build` jobs — it only breaks in the zero-dep job. Classic environment-dependent test bug.

## Fix

Patch `_HAS_STRIPE` alongside `stripe_sdk` so the mocked Stripe path is genuinely exercised either way. Product code is untouched — this was a test defect, not a `reconcile()` bug.

## Verification

Run locally in both configurations:

| Environment | Result |
|---|---|
| without `stripe` (mirrors zero-dep job) | **539 passed, 10 skipped** |
| with `stripe` 15.5.1 | **539 passed, 10 skipped** |

Before the fix, the no-stripe run was `6 failed, 9 passed` for `tests/test_reconcile.py`.