### PR TITLE
ci: add PyPI Trusted Publishing workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,31 @@
+name: Publish to PyPI
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+jobs:
+  publish:
+    name: Publish to PyPI
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+
+      - name: Install build
+        run: python -m pip install --upgrade build
+
+      - name: Build package
+        run: python -m build
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
## Summary
- Add `.github/workflows/publish.yml` for PyPI Trusted Publishing (`pypa/gh-action-pypi-publish`, `id-token: write`, on `release` published + `workflow_dispatch`).
- README already states PyPI publish is pending (package **not** on PyPI); no install-line change to a live `pip install solvent-agent`.

## Registry status
`https://pypi.org/pypi/solvent-agent/json` → **404** (not published).

## Ian must do on PyPI (before first publish)
1. Log in at https://pypi.org/
2. Publishing → **Pending publishers** (or create project `solvent-agent` then Trusted publishers)
3. Add GitHub publisher:
   - **PyPI project name:** `solvent-agent`
   - **Owner:** `ianalloway`
   - **Repository:** `solvent-agent`
   - **Workflow filename:** `publish.yml`
   - Environment: leave blank
4. After merge: GitHub Release or workflow_dispatch to publish.

## Test plan
- [ ] Workflow appears under Actions
- [ ] Link trusted publisher, then publish first release